### PR TITLE
Make allocator thread-safe and switch to Rust's stabilised `GlobalAlloc` API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ impl<'a> Iterator for AllocListIter<'a> {
 
 impl AllocList {
     fn new() -> AllocList {
-        let raw = unsafe { libc::malloc(SIZE_ALLOC_INFO as libc::size_t) } as *mut Block;
+        let raw = unsafe { libc::malloc(SIZE_ALLOC_INFO as libc::size_t) } as *const Block;
         AllocList {
             start: raw,
             next_free: 0,


### PR DESCRIPTION
This PR includes two key changes:

1. Access to the `ALLOC_INFO` list - which contains metadata about each allocation block - is now thread-safe. 

2. Allocation is now done via Rust's [GlobalAlloc](https://doc.rust-lang.org/beta/std/alloc/trait.GlobalAlloc.html) API.

Please see the individual commit messages for more detailed information about each change