### PR TITLE
Separate managed GC allocation from standard system allocation

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -43,7 +43,7 @@ use std::{
 
 static SIZE_ALLOC_INFO: usize = (1024 * 1024) * 2; // 2MiB
 
-static mut ALLOC_INFO: Option<AllocList> = None;
+pub(crate) static mut ALLOC_INFO: Option<AllocList> = None;
 
 /// A spinlock for the global ALLOC_INFO list.
 ///

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -40,7 +40,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-static SIZE_ALLOC_INFO: usize = (1024 * 1024) * 2; // 2KB
+static SIZE_ALLOC_INFO: usize = (1024 * 1024) * 2; // 2MiB
 
 static mut ALLOC_INFO: Option<AllocList> = None;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,10 +38,15 @@
 #![crate_name = "gcmalloc"]
 #![crate_type = "rlib"]
 #![feature(core_intrinsics)]
+#![feature(allocator_api)]
 
 mod alloc;
 
-use crate::alloc::GCMalloc;
+use crate::alloc::{AllocWithInfo, GCMalloc};
 
 #[global_allocator]
-static ALLOCATOR: GCMalloc = GCMalloc;
+static ALLOCATOR: AllocWithInfo = AllocWithInfo;
+
+/// Used for allocation of objects which are managed by the collector (through
+/// the `Gc` smart pointer interface).
+static mut GC_ALLOCATOR: GCMalloc = GCMalloc;


### PR DESCRIPTION
We intend to use GC alongside normal RAII style memory allocation. This means that during a collection, the collector needs to know which blocks in the heap it is responsible for reclaiming.

This PR includes a separate allocator -- `GC_ALLOCATOR` -- intended to be used instead of the global allocator for GC objects. `GC_ALLOCATOR` ensures that the block is recorded inside the `ALLOC_INFO` list as being GC managed. This info can then be queried during a collection.