### PR TITLE
Add lang_test framework for testing full programs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,13 @@ edition = "2018"
 
 [dependencies]
 libc = "*"
+
+[dev-dependencies]
+lang_tester = "0.3"
+tempdir = "0.3"
+
+[[test]]
+name = "gc_tests"
+path = "gc_tests/run_tests.rs"
+harness = false
+

--- a/gc_tests/run_tests.rs
+++ b/gc_tests/run_tests.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2019 King's College London created by the Software Development
+// Team <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT
+// or http://opensource.org/licenses/MIT>, or the UPL-1.0 license
+// <http://opensource.org/licenses/UPL> at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use std::{env, path::PathBuf, process::Command};
+
+use lang_tester::LangTester;
+use tempdir::TempDir;
+
+static CRATE_NAME: &'static str = "gcmalloc";
+
+fn main() {
+    // We grab the rlibs from `target/<debug | release>/` but in order
+    // for them to exist here, they must have been moved from `deps/`.
+    // Simply running `cargo test` will not do this, instead, we must
+    // ensure that `cargo build` has been run before running the tests.
+    Command::new("cargo")
+        .args(&["build"])
+        .output()
+        .expect("Failed to build libs");
+
+    let tempdir = TempDir::new("gc_tester").unwrap();
+    LangTester::new()
+        .test_dir("gc_tests/tests")
+        .test_file_filter(|p| p.extension().unwrap().to_str().unwrap() == "rs")
+        .test_extract(|s| {
+            Some(
+                s.lines()
+                    .take_while(|l| l.starts_with("//"))
+                    .map(|l| &l[2..])
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            )
+        })
+        .test_cmds(move |p| {
+            // Test command 1: Compile `x.rs` into `tempdir/x`.
+            let mut exe = PathBuf::new();
+            exe.push(&tempdir);
+            exe.push(p.file_stem().unwrap());
+            let mut compiler = Command::new("rustc");
+
+            let mut lib_path = PathBuf::new();
+            lib_path.push(env::var("CARGO_MANIFEST_DIR").unwrap());
+            lib_path.push("target");
+            #[cfg(debug_assertions)]
+            lib_path.push("debug");
+            #[cfg(not(debug_assertions))]
+            lib_path.push("release");
+            lib_path.push("libgcmalloc.rlib");
+
+            let mut deps_path = PathBuf::new();
+            deps_path.push(env::var("CARGO_MANIFEST_DIR").unwrap());
+            deps_path.push("target");
+            #[cfg(debug_assertions)]
+            deps_path.push("debug");
+            #[cfg(not(debug_assertions))]
+            deps_path.push("release");
+            deps_path.push("deps");
+
+            let lib_arg = [CRATE_NAME, "=", lib_path.to_str().unwrap()].concat();
+            let deps_arg = ["dependency=", deps_path.to_str().unwrap()].concat();
+
+            compiler.args(&[
+                "--edition=2018",
+                "-o",
+                exe.to_str().unwrap(),
+                p.to_str().unwrap(),
+                "--crate-name",
+                CRATE_NAME,
+                "-L",
+                deps_arg.as_str(),
+                "--extern",
+                lib_arg.as_str(),
+            ]);
+
+            let runtime = Command::new(exe);
+            vec![("Compiler", compiler), ("Run-time", runtime)]
+        })
+        .run();
+}

--- a/gc_tests/tests/alloc_info_oom.rs
+++ b/gc_tests/tests/alloc_info_oom.rs
@@ -1,0 +1,13 @@
+// Run-time:
+//  status: error
+
+extern crate gcmalloc;
+
+static NUM_ALLOCATIONS: usize = 100000;
+
+fn main() {
+    let mut v = Vec::with_capacity(NUM_ALLOCATIONS);
+    for i in 0..NUM_ALLOCATIONS {
+        v.push(Box::new(i));
+    }
+}

--- a/gc_tests/tests/alloc_info_oom.rs
+++ b/gc_tests/tests/alloc_info_oom.rs
@@ -1,5 +1,6 @@
 // Run-time:
 //  status: error
+//  stderr: Allocation failed: Metadata list full
 
 extern crate gcmalloc;
 

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -292,7 +292,7 @@ impl AllocList {
         }
 
         // The allocation list is full
-        abort();
+        exit_alloc("Allocation failed: Metadata list full");
     }
 
     /// Remove ptr information associated with a base pointer (perfomed on a
@@ -377,8 +377,9 @@ pub struct PtrInfo {
     pub gc: bool,
 }
 
-fn abort() {
-    unsafe { core::intrinsics::abort() };
+fn exit_alloc(msg: &str) {
+    unsafe { libc::write(2, msg.as_ptr() as *const libc::c_void, msg.len()) };
+    std::process::exit(1);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
With conservative scanning, a proper testing framework is necessary as we want to run programs from start to finish. This PR sets up `lang_tester` for this purpose. There aren't many tests here yet because they won't make sense without the stack scanning code.