### PR TITLE
Use rerun_except to stop lang_tests forcing unnecessary rebuilds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 libc = "*"
 
 [build-dependencies]
+rerun_except = "0.1"
 cc = "1.0"
 
 [dev-dependencies]
@@ -18,4 +19,3 @@ tempdir = "0.3"
 name = "gc_tests"
 path = "gc_tests/run_tests.rs"
 harness = false
-

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,10 @@
 extern crate cc;
 
+use rerun_except::rerun_except;
+
 fn main() {
+    rerun_except(&["gc_tests/tests/*.rs"]).unwrap();
+
     cc::Build::new()
         .file("src/SpillRegisters_X64.S")
         .compile("libSpillRegisters.a");


### PR DESCRIPTION
Changing a lang test in `gc_tests/tests` currently triggers a full rebuild of `gcmalloc`, despite that being unnecessary. Using `rerun_except` stops this happening.