### PR TITLE
Trace through allocation blocks during collection

### DIFF
--- a/gc_tests/tests/mark_through_gc_objects.rs
+++ b/gc_tests/tests/mark_through_gc_objects.rs
@@ -1,0 +1,53 @@
+// Run-time:
+//   status: success
+
+extern crate gcmalloc;
+
+use gcmalloc::{collect, gc::DebugFlags, Debug, Gc};
+
+struct GcData {
+    a: Gc<usize>,
+    b: Gc<usize>,
+}
+
+struct OnRustHeap {
+    a: Option<Box<OnRustHeap>>,
+    b: Gc<GcData>,
+}
+
+fn make_objgraph() -> Box<OnRustHeap> {
+    let x = GcData {
+        a: Gc::new(10),
+        b: Gc::new(20),
+    };
+
+    let y = GcData {
+        a: Gc::new(30),
+        b: Gc::new(40),
+    };
+
+    let inner_rh = OnRustHeap {
+        a: None,
+        b: Gc::new(x),
+    };
+
+    let outer_rh = Box::new(OnRustHeap {
+        a: Some(Box::new(inner_rh)),
+        b: Gc::new(y),
+    });
+
+    outer_rh
+}
+
+fn main() {
+    gcmalloc::init(DebugFlags::new().mark_only());
+
+    let objgraph = make_objgraph();
+    gcmalloc::collect();
+
+    let x = objgraph.a.unwrap().b;
+    let y = objgraph.b;
+
+    assert!(Debug::is_black(x));
+    assert!(Debug::is_black(y));
+}

--- a/gc_tests/tests/mark_through_std_collections.rs
+++ b/gc_tests/tests/mark_through_std_collections.rs
@@ -1,0 +1,36 @@
+extern crate gcmalloc;
+
+use gcmalloc::{collect, gc::DebugFlags, Debug, Gc};
+
+struct GcData {
+    a: Gc<usize>,
+    b: Gc<Gc<usize>>,
+}
+
+impl GcData {
+    fn new(a: Gc<usize>, b: Gc<Gc<usize>>) -> Self {
+        Self { a, b }
+    }
+}
+
+fn make_objgraph() -> Vec<GcData> {
+    let mut gcs = Vec::new();
+    for i in 1..1000 {
+        gcs.push(GcData::new(Gc::new(i), Gc::new(Gc::new(1))))
+    }
+    gcs
+}
+
+fn main() {
+    gcmalloc::init(DebugFlags::new().mark_only());
+
+    let objgraph = make_objgraph();
+    gcmalloc::collect();
+
+    // for gcdata in objgraph.iter() {
+    //     for i in gcdata.b.iter() {
+    //         assert!(Debug::is_black(*i));
+    //     }
+    //     // assert!(Debug::is_black(gcdata.a));
+    // }
+}

--- a/gc_tests/tests/on_stack_root_marking.rs
+++ b/gc_tests/tests/on_stack_root_marking.rs
@@ -3,9 +3,7 @@
 
 extern crate gcmalloc;
 
-use gcmalloc::Gc;
-use gcmalloc::{collect, Debug };
-use gcmalloc::gc::DebugFlags;
+use gcmalloc::{collect, gc::DebugFlags, Debug, Gc};
 
 fn foo() {
     let y = Gc::new(456 as usize);

--- a/gc_tests/tests/simple_cyclic_objgraph.rs
+++ b/gc_tests/tests/simple_cyclic_objgraph.rs
@@ -1,0 +1,58 @@
+// Run-time:
+//   status: success
+
+extern crate gcmalloc;
+
+use gcmalloc::{collect, gc::DebugFlags, Debug, Gc};
+
+struct Node {
+    data: String,
+    edge: Option<Gc<Node>>,
+}
+
+fn make_objgraph() -> Gc<Node> {
+    let mut a = Gc::new(Node {
+        data: "a".to_string(),
+        edge: None,
+    });
+    let mut b = Gc::new(Node {
+        data: "b".to_string(),
+        edge: None,
+    });
+    let mut c = Gc::new(Node {
+        data: "c".to_string(),
+        edge: None,
+    });
+
+    a.edge = Some(b);
+    b.edge = Some(c);
+    c.edge = Some(a);
+
+    a
+}
+
+fn main() {
+    gcmalloc::init(DebugFlags::new().mark_only());
+
+    let a = make_objgraph();
+    gcmalloc::collect();
+
+    // Test a
+    assert_eq!(a.data, String::from("a"));
+    assert!(Debug::is_black(a));
+
+    // Test b
+    assert_eq!(a.edge.unwrap().data, String::from("b"));
+    assert!(Debug::is_black(a.edge.unwrap()));
+
+    // Test c
+    assert_eq!(a.edge.unwrap().edge.unwrap().data, String::from("c"));
+    assert!(Debug::is_black(a.edge.unwrap().edge.unwrap()));
+
+    // Test c -> a
+    assert_eq!(
+        a.edge.unwrap().edge.unwrap().edge.unwrap().data,
+        String::from("a")
+    );
+    assert!(Debug::is_black(a.edge.unwrap().edge.unwrap().edge.unwrap()));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use crate::{
 use std::{
     alloc::{Alloc, Layout},
     mem::{forget, size_of},
-    ops::Deref,
+    ops::{Deref, DerefMut},
     ptr,
 };
 
@@ -135,8 +135,14 @@ impl GcHeader {
 impl<T> Deref for Gc<T> {
     type Target = T;
 
-    fn deref(&self) -> &T {
+    fn deref(&self) -> &Self::Target {
         unsafe { &*(self.objptr as *const T) }
+    }
+}
+
+impl<T> DerefMut for Gc<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *(self.objptr as *mut T) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,10 @@ impl<T> Gc<T> {
             let baseptr = GC_ALLOCATOR.alloc(layout).unwrap().as_ptr();
             let objptr = baseptr.add(uoff);
 
-            AllocMetadata::insert(objptr as usize, layout.size(), true);
+            // size excl. header and padding
+            let objsize = layout.size() - (objptr as usize - baseptr as usize);
+            AllocMetadata::insert(objptr as usize, objsize, true);
+
             let headerptr = objptr.sub(size_of::<usize>());
             ptr::write(headerptr as *mut GcHeader, GcHeader::new());
             objptr as *mut T

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@ static mut GC_ALLOCATOR: GCMalloc = GCMalloc;
 
 static mut COLLECTOR: Option<Collector> = None;
 
-#[derive(Clone, Copy)]
 pub struct Gc<T> {
     objptr: *mut T,
 }
@@ -143,6 +142,17 @@ impl<T> Deref for Gc<T> {
 impl<T> DerefMut for Gc<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *(self.objptr as *mut T) }
+    }
+}
+
+/// `Copy` and `Clone` are implemented manually because a reference to `Gc<T>`
+/// should be copyable regardless of `T`. It differs subtly from `#[derive(Copy,
+/// Clone)]` in that the latter only makes `Gc<T>` copyable if `T` is.
+impl<T> Copy for Gc<T> {}
+
+impl<T> Clone for Gc<T> {
+    fn clone(&self) -> Self {
+        *self
     }
 }
 


### PR DESCRIPTION
After stack scanning, where the root-set is added to the marking worklist, the collector traces through each heap allocation looking for further pointers. This completes the necessary steps for the mark phase.

The other important change in this PR is that we make `Gc<T>` copyable for all values of `T`. This seriously improves its ergonomics (as seen in the various new `gc_tests`). It means that `Gc<T>` is now a real viable alternative for writing cyclic data structures. Unlike `Rc<T>` and friends, we can make this trivially copyable because we don't need to implement `Drop`. The collector cleans up for us at some non-deterministic point in the future. That's not to say we won't need some alternative form of finalization in the future; but it won't be `Drop` because it's not bound by Rust's RAII guarantees.