### PR TITLE
Run sanitizers on tests

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -13,4 +13,9 @@ export PATH=`pwd`/.cargo/bin/:$PATH
 rustup component add --toolchain nightly rustfmt-preview || cargo +nightly install --force rustfmt-nightly
 
 cargo +nightly fmt --all -- --check
+
 cargo test
+
+# Run gc tests with sanitizers
+SANITIZERS="thread" cargo test --test gc_tests --target x86_64-unknown-linux-gnu
+VALGRIND="true" cargo test --test gc_tests --target x86_64-unknown-linux-gnu

--- a/gc_tests/tests/alloc_info_oom.rs
+++ b/gc_tests/tests/alloc_info_oom.rs
@@ -1,6 +1,9 @@
 // Run-time:
 //  status: error
-//  stderr: Allocation failed: Metadata list full
+//  stderr:
+//      ...
+//      Allocation failed: Metadata list full
+//      ...
 
 extern crate gcmalloc;
 

--- a/gc_tests/valgrind.supp
+++ b/gc_tests/valgrind.supp
@@ -1,0 +1,7 @@
+{
+   <uninitialized_stack>
+   Memcheck:Cond
+   ...
+   fun:scan_stack
+}
+

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -125,7 +125,7 @@ impl AllocLock {
     }
 
     fn lock(&self) {
-        while !self.0.compare_and_swap(false, true, Ordering::AcqRel) {
+        while self.0.compare_and_swap(false, true, Ordering::AcqRel) {
             // Spin
         }
     }

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -397,6 +397,7 @@ impl AllocMetadata {
     }
 
     /// Removes the metadata associated with an allocation.
+    #[cfg(test)]
     pub(crate) fn remove(ptr: usize) {
         ALLOC_LOCK.lock();
 

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -11,6 +11,7 @@ use std::{
     alloc::{Alloc, AllocErr, GlobalAlloc, Layout},
     ptr::NonNull,
     sync::atomic::{AtomicBool, Ordering},
+    mem::size_of,
 };
 
 static SIZE_ALLOC_INFO: usize = (1024 * 1024) * 2; // 2MiB
@@ -230,7 +231,8 @@ impl AllocList {
         if self.can_bump {
             unsafe {
                 let next_ptr = self.start.add(self.next_free) as *mut Block;
-                if (next_ptr as usize) < self.start as usize + SIZE_ALLOC_INFO {
+                let last = self.start as usize + SIZE_ALLOC_INFO - size_of::<Block>();
+                if (next_ptr as usize) <= last {
                     *next_ptr = Block::Entry(core::num::NonZeroUsize::new_unchecked(ptr), size, gc);
                     self.next_free += 1;
                     return;

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -172,6 +172,12 @@ impl<'a> Iterator for AllocListIterMut<'a> {
             return None;
         }
 
+        // If we're still doing bump insertion, then there's a chunk of the list
+        // which remains uninitialized.
+        if self.alloc_list.can_bump && self.idx >= self.alloc_list.next_free {
+            return None;
+        }
+
         let ptr = self.alloc_list.start as usize + (self.idx * core::mem::size_of::<Block>());
         self.idx += 1;
 
@@ -186,6 +192,12 @@ impl<'a> Iterator for AllocListIter<'a> {
         // It's UB to call `.add` on a pointer past its allocation bounds, so we
         // need to check that it's within range before turning it into a pointer
         if self.idx * core::mem::size_of::<Block>() >= SIZE_ALLOC_INFO {
+            return None;
+        }
+
+        // If we're still doing bump insertion, then there's a chunk of the list
+        // which remains uninitialized.
+        if self.alloc_list.can_bump && self.idx >= self.alloc_list.next_free {
             return None;
         }
 

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -168,7 +168,7 @@ impl<'a> Iterator for AllocListIterMut<'a> {
         // It's UB to call `.add` on a pointer past its allocation bounds, so we
         // need to check that it's within range before turning it into a pointer
         // and dereferencing it
-        if self.idx * core::mem::size_of::<Block>() >= SIZE_ALLOC_INFO {
+        if self.idx * size_of::<Block>() >= (SIZE_ALLOC_INFO - size_of::<Block>()) {
             return None;
         }
 

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -9,9 +9,9 @@
 
 use std::{
     alloc::{Alloc, AllocErr, GlobalAlloc, Layout},
+    mem::size_of,
     ptr::NonNull,
     sync::atomic::{AtomicBool, Ordering},
-    mem::size_of,
 };
 
 static SIZE_ALLOC_INFO: usize = (1024 * 1024) * 2; // 2MiB
@@ -178,7 +178,7 @@ impl<'a> Iterator for AllocListIterMut<'a> {
             return None;
         }
 
-        let ptr = self.alloc_list.start as usize + (self.idx * core::mem::size_of::<Block>());
+        let ptr = self.alloc_list.start as usize + (self.idx * size_of::<Block>());
         self.idx += 1;
 
         unsafe { Some(&mut *(ptr as *mut Block)) }
@@ -191,7 +191,7 @@ impl<'a> Iterator for AllocListIter<'a> {
     fn next(&mut self) -> Option<&'a Block> {
         // It's UB to call `.add` on a pointer past its allocation bounds, so we
         // need to check that it's within range before turning it into a pointer
-        if self.idx * core::mem::size_of::<Block>() >= SIZE_ALLOC_INFO {
+        if self.idx * size_of::<Block>() >= SIZE_ALLOC_INFO {
             return None;
         }
 
@@ -201,7 +201,7 @@ impl<'a> Iterator for AllocListIter<'a> {
             return None;
         }
 
-        let ptr = self.alloc_list.start as usize + (self.idx * core::mem::size_of::<Block>());
+        let ptr = self.alloc_list.start as usize + (self.idx * size_of::<Block>());
         self.idx += 1;
 
         let entry = unsafe { &*(ptr as *const Block) };

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -268,7 +268,7 @@ impl AllocList {
         }
 
         // The allocation list is full
-        exit_alloc("Allocation failed: Metadata list full");
+        exit_alloc("Allocation failed: Metadata list full\n");
     }
 
     /// Remove ptr information associated with a base pointer (perfomed on a
@@ -355,7 +355,7 @@ pub struct PtrInfo {
 
 fn exit_alloc(msg: &str) {
     unsafe { libc::write(2, msg.as_ptr() as *const libc::c_void, msg.len()) };
-    std::process::exit(1);
+    std::process::abort();
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
This PR ensures that thread sanitizer and valgrind are run on `gc_tests` as part of the buildbot configuration now. 

After the initial setup, both valgrind and TSAN found quite a few bugs! So there are also fixes for each one.