### PR TITLE
Refactor alloc metadata calls.

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -24,9 +24,8 @@ static mut ALLOC_INFO: Option<AllocList> = None;
 /// metadata about each allocation to shared memory upon returning from the
 /// system allocator call. This requires additional synchronisation mechanisms.
 /// It is not possible to use `sys::Sync::Mutex` for this purpose as the
-/// implementation includes a heap allocation containing a `pthread_mutex`. This
-/// would cause infinite recursion when initialising the lock as the allocator
-/// would call itself.
+/// implementation includes a heap allocation containing a `pthread_mutex`.
+/// Since `alloc` and friends are not re-entrant, it's not possible to use this.
 ///
 /// Instead, we use a simple global spinlock built on an atomic bool to guard
 /// access to the ALLOC_INFO list.


### PR DESCRIPTION
When tracking down some bugs as part of the sanitizer support PR, I had refactored the allocation metadata into a single API to see if that was responsible for some of my concurrency bugs. Alas, it was not, but it simplifies the code anyway and results in some deletion so it's worth checking in.

The unit tests have also been refactored to use the global allocator API too, which provides better coverage when running the tests with TSAN. This also ensures that `AllocMetadata::remove` is tested correctly and no longer dead code.