### PR TITLE
Add drop phase to GC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,47 @@
 # gcmalloc
 
 A Rust allocator with support for conservative garbage collection.
+
+## The Drop Trait
+
+`Gc` values implement the `Drop` trait. Unlike non-garbage-collected values,
+however, the `drop` method is not called when a `Gc` value goes out of scope.
+Instead, once the collector has determined that a value is garbage, it is added
+to a drop queue, where its `drop` method is ran at an indeterminate point in the
+future. This means that `Drop` now acts as both a regular destructor in the
+presence of scoped values, and a garbage collection finalizer when applied to
+`Gc` values.
+
+As with regular destructors, `drop` methods on `Gc` values are run from the
+"outside-in". However, if there are cycles, there is no way to know which `drop`
+method is safe to run first. Consider the example below:
+
+```rust
+
+struct Node<T> {
+    edge: Option<Gc<T>>
+}
+
+impl<T> Drop for Inner<T> {
+    fn drop(&mut self) {
+        println!("Points to: {}", self.edge.unwrap())
+    }
+}
+
+let x = Gc::new(Node { edge: None })
+let y = Gc::new(Node { edge: None })
+
+x.edge = Some(y);
+y.edge = Some(x);
+
+```
+
+Since an object is deallocated after its `drop` method is run, there is no safe
+order to run these destructors. If `x`'s `drop` method is called first, dropping
+`y` will dereference a dangling pointer. The same is true in the inverse order.
+
+To solve this, we impose an additional restriction on the `Drop` trait: you must
+not dereference a `Gc` inside the `drop` method. This works because unsafe
+`Drop` cycles can only be created using `Gc`s. By forbidding `drop` from
+derefing through `Gc`s, we can ensure `drop` only has access to resources which
+are guaranteed to be live.

--- a/gc_tests/tests/collect_runs_drop.rs
+++ b/gc_tests/tests/collect_runs_drop.rs
@@ -1,0 +1,26 @@
+// Run-time:
+//  status: success
+
+extern crate gcmalloc;
+
+use gcmalloc::{gc::DebugFlags, Gc};
+
+static mut COUNTER: usize = 0;
+
+struct IncrOnDrop(usize);
+
+impl Drop for IncrOnDrop {
+    fn drop(&mut self) {
+        unsafe { COUNTER += 1 }
+    }
+}
+
+fn main() {
+    gcmalloc::init(DebugFlags::new().mark_phase(false));
+
+    Gc::new(IncrOnDrop(123));
+
+    gcmalloc::collect();
+
+    unsafe { assert_eq!(COUNTER, 1) }
+}

--- a/gc_tests/tests/cyclic_destructors.rs
+++ b/gc_tests/tests/cyclic_destructors.rs
@@ -1,0 +1,49 @@
+// Run-time:
+//   status: success
+
+extern crate gcmalloc;
+
+use gcmalloc::{collect, gc::DebugFlags, Debug, Gc};
+
+static mut COUNTER: usize = 0;
+
+struct Node {
+    data: String,
+    edge: Option<Gc<Node>>,
+}
+
+impl Drop for Node {
+    fn drop(&mut self) {
+        unsafe { COUNTER += 1 }
+    }
+}
+
+fn make_objgraph() -> Gc<Node> {
+    let mut a = Gc::new(Node {
+        data: "a".to_string(),
+        edge: None,
+    });
+    let mut b = Gc::new(Node {
+        data: "b".to_string(),
+        edge: None,
+    });
+    let mut c = Gc::new(Node {
+        data: "c".to_string(),
+        edge: None,
+    });
+
+    a.edge = Some(b);
+    b.edge = Some(c);
+    c.edge = Some(a);
+
+    a
+}
+
+fn main() {
+    gcmalloc::init(DebugFlags::new().mark_phase(false));
+
+    let a = make_objgraph();
+    gcmalloc::collect();
+
+    unsafe { assert_eq!(COUNTER, 3) };
+}

--- a/gc_tests/tests/destructors_inner_gc.rs
+++ b/gc_tests/tests/destructors_inner_gc.rs
@@ -1,0 +1,29 @@
+// Run-time:
+//  status: success
+
+extern crate gcmalloc;
+
+use gcmalloc::{gc::DebugFlags, Gc};
+
+static mut COUNTER: usize = 0;
+
+struct HasInnerGc(Gc<IncrOnDrop>);
+
+struct IncrOnDrop(Option<Box<IncrOnDrop>>);
+
+impl Drop for IncrOnDrop {
+    fn drop(&mut self) {
+        unsafe { COUNTER += 1 }
+    }
+}
+
+fn main() {
+    gcmalloc::init(DebugFlags::new().mark_phase(false));
+
+    let s = HasInnerGc(Gc::new(IncrOnDrop(None)));
+    Gc::new(s);
+
+    gcmalloc::collect();
+
+    unsafe { assert_eq!(COUNTER, 1) }
+}

--- a/gc_tests/tests/no_drop_live_inner.rs
+++ b/gc_tests/tests/no_drop_live_inner.rs
@@ -1,0 +1,32 @@
+// Run-time:
+//  status: success
+
+extern crate gcmalloc;
+
+use gcmalloc::{gc::DebugFlags, Debug, Gc};
+
+static mut COUNTER: usize = 0;
+
+struct HasInnerGc(Gc<IncrOnDrop>);
+
+struct IncrOnDrop(Option<Box<IncrOnDrop>>);
+
+impl Drop for IncrOnDrop {
+    fn drop(&mut self) {
+        unsafe { COUNTER += 1 }
+    }
+}
+
+// This tests that if an inner Gc is kept alive from some reference outside a
+// dying outer Gc, the inner destructor should *not* be ran.
+fn main() {
+    gcmalloc::init(DebugFlags::new().mark_phase(false));
+
+    let inner = Gc::new(IncrOnDrop(None));
+    unsafe { Debug::keep_alive(inner) };
+    let outer = Gc::new((IncrOnDrop(None), HasInnerGc(inner)));
+
+    gcmalloc::collect();
+
+    unsafe { assert_eq!(COUNTER, 1) }
+}

--- a/gc_tests/tests/recursive_destructors.rs
+++ b/gc_tests/tests/recursive_destructors.rs
@@ -1,0 +1,27 @@
+// Run-time:
+//  status: success
+
+extern crate gcmalloc;
+
+use gcmalloc::{gc::DebugFlags, Gc};
+
+static mut COUNTER: usize = 0;
+
+struct IncrOnDrop(Option<Box<IncrOnDrop>>);
+
+impl Drop for IncrOnDrop {
+    fn drop(&mut self) {
+        unsafe { COUNTER += 1 }
+    }
+}
+
+fn main() {
+    gcmalloc::init(DebugFlags::new().mark_phase(false));
+
+    let s = IncrOnDrop(Some(Box::new(IncrOnDrop(Some(Box::new(IncrOnDrop(None)))))));
+    Gc::new(s);
+
+    gcmalloc::collect();
+
+    unsafe { assert_eq!(COUNTER, 3) }
+}

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -1,6 +1,6 @@
 use crate::{
     alloc::{AllocMetadata, PtrInfo, BLOCK_METADATA},
-    GcBox, Trace,
+    GcBox,
 };
 
 use std::{
@@ -238,8 +238,8 @@ impl Collector {
     /// creating a hollow `Gc<Placeholder>` struct with `Gc::from_raw`.
     /// `Gc::new()` must *not* be used.
     fn dealloc(&self, boxptr: *mut GcBox<OpaqueU8>) {
-        let vptr = unsafe { (&*boxptr).vptr() };
-        let drop_trobj: &mut dyn Trace = unsafe { transmute((boxptr, vptr)) };
+        let vptr = unsafe { (&*boxptr).drop_vptr() };
+        let drop_trobj: &mut dyn Drop = unsafe { transmute((boxptr, vptr)) };
         let size = size_of_val(drop_trobj);
         let align = align_of_val(drop_trobj);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,27 +37,6 @@ static ALLOCATOR: GlobalAllocator = GlobalAllocator;
 
 static mut COLLECTOR: Option<Collector> = None;
 
-/// Used to specify how a value is traversed by a garbage collector.
-///
-/// In order for a value to be managed by the garbage collector, its type, `T`,
-/// must implement `Trace`. The `trace` method tells the garbage collector where
-/// to find `Gc` values reachable from `T`. Fields which reference `Gc` values
-/// -- either directly or indirectly -- are included in the `trace` method,
-/// which is then called by the garbage collector when marking objects.
-///
-/// TODO: This trait is only necessary for precise tracing of garbage collected
-/// objects. At the moment, is not used because all objects are conservatively
-/// scanned, word-by-word, looking for values which resemble pointers. However,
-/// we still implement `Trace` on all `Gc`s.
-///
-/// Since the goal is that garbage collected objects are eventually traced
-/// precisely using the trait-based `Trace` API, requiring this upfront serves
-/// as a useful placeholder so that we can use the trait-object based layout
-/// trick in the meantime.
-pub(crate) trait Trace {
-    fn trace(&self) {}
-}
-
 /// A garbage collected pointer. 'Gc' stands for 'Garbage collected'.
 ///
 /// The type `Gc<T>` provides shared ownership of a value of type `T`,
@@ -118,9 +97,9 @@ impl<T> GcBox<T> {
             ptr.copy_from_nonoverlapping(&gcb, 1);
         }
 
-        let fatptr: &dyn Trace = &gcb;
+        let fatptr: &dyn Drop = &gcb;
         unsafe {
-            let vptr = transmute::<*const dyn Trace, (usize, usize)>(fatptr).1;
+            let vptr = transmute::<*const dyn Drop, (usize, usize)>(fatptr).1;
             (&mut *ptr).set_header(GcHeader::new(vptr));
         }
 
@@ -175,8 +154,9 @@ impl<T> GcBox<T> {
         self.set_header(header);
     }
 
-    pub(crate) fn vptr(&self) -> usize {
-        *self.header().trace_vptr as usize
+    pub(crate) fn drop_vptr(&self) -> *mut u8 {
+        let vptr = *self.header().drop_vptr as u64;
+        vptr as usize as *mut u8
     }
 }
 
@@ -186,9 +166,9 @@ impl<T> GcBox<T> {
 #[derive(PackedStruct, Debug)]
 #[packed_struct(bit_numbering = "msb0", size_bytes = "8")]
 pub struct GcHeader {
-    /// The pointer to the vtable for `Gc<T>`s `Trace` implementation.
-    #[packed_field(bits = "0..=62", endian = "msb")]
-    trace_vptr: Integer<u64, packed_bits::Bits62>,
+    /// The pointer to the vtable for `Gc<T>`s `Drop` implementation.
+    #[packed_field(bits = "0..=61", endian = "msb")]
+    drop_vptr: Integer<u64, packed_bits::Bits62>,
     /// Used by the GC during the marking phase
     #[packed_field(bits = "63")]
     mark_bit: bool,
@@ -198,7 +178,7 @@ impl GcHeader {
     pub(crate) fn new(vptr: usize) -> Self {
         let white = unsafe { !COLLECTOR.as_ref().unwrap().current_black() };
         GcHeader {
-            trace_vptr: (vptr as u64).into(),
+            drop_vptr: (vptr as u64).into(),
             mark_bit: white,
         }
     }
@@ -232,8 +212,6 @@ impl<T> Clone for Gc<T> {
         *self
     }
 }
-
-impl<T> Trace for GcBox<T> {}
 
 /// Initialize the garbage collector. This *must* happen before any `Gc<T>`s are
 /// allocated.


### PR DESCRIPTION
Previously, the sweep phase would deallocate objects in-place, potentially causing leaks as their `drop` method was not called. In this PR, the collector queues dead objects for destruction while sweeping. It then enters the drop phase, where it iterates over the drop queue calling each object's destructor.