### PR TITLE
Track allocations using a linked-list

### DIFF
--- a/gc_tests/valgrind.supp
+++ b/gc_tests/valgrind.supp
@@ -5,3 +5,9 @@
    fun:scan_stack
 }
 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:_ZN8gcmalloc2gc9Collector16enter_mark_phase*
+   ...
+}

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -1,18 +1,15 @@
 use stdalloc::raw_vec::RawVec;
 
 use std::{
-    alloc::{GlobalAlloc, Layout, System},
+    alloc::{Alloc, AllocErr, GlobalAlloc, Layout, System},
+    ptr,
+    ptr::NonNull,
     sync::atomic::{AtomicBool, Ordering},
 };
 
-/// Used by the global allocator to store metadata about every allocated block.
-///
-/// This information is vital for the collector to know things such as: whether
-/// an arbitrary word in a block is a ptr; how to get to the beginning of a
-/// block from some inner ptr; and whether a block is managed by the collector.
-pub(crate) static mut BLOCK_METADATA: VOH<PtrInfo> = VOH::new();
+use packed_struct::prelude::*;
 
-/// A spinlock for the global ALLOC_INFO list.
+/// A spinlock for keeping allocation thread-safe.
 ///
 /// System allocators are generally thread-safe, but gcmalloc reads and writes
 /// metadata about each allocation to shared memory upon returning from the
@@ -20,33 +17,180 @@ pub(crate) static mut BLOCK_METADATA: VOH<PtrInfo> = VOH::new();
 /// It is not possible to use `sys::Sync::Mutex` for this purpose as the
 /// implementation includes a heap allocation containing a `pthread_mutex`.
 /// Since `alloc` and friends are not re-entrant, it's not possible to use this.
-///
-/// Instead, we use a simple global spinlock built on an atomic bool to guard
-/// access to the ALLOC_INFO list.
 static ALLOC_LOCK: AllocLock = AllocLock::new();
 
+static mut LAST_ALLOCED: *mut BlockHeader = ::std::ptr::null_mut();
+
 pub struct GlobalAllocator;
+pub struct GcAllocator;
 
 unsafe impl GlobalAlloc for GlobalAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let ptr = libc::malloc(layout.size() as libc::size_t) as *mut u8;
-        AllocMetadata::insert(ptr as usize, layout.size(), false);
-        ptr
+        alloc(layout, false)
     }
 
-    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-        libc::free(ptr as *mut libc::c_void);
-        AllocMetadata::remove(ptr as usize);
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        dealloc(ptr, layout);
     }
 
-    unsafe fn realloc(&self, ptr: *mut u8, _layout: Layout, new_size: usize) -> *mut u8 {
-        let new_ptr = libc::realloc(ptr as *mut libc::c_void, new_size) as *mut u8;
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        realloc(ptr, layout, new_size)
+    }
+}
 
-        assert!(!ptr.is_null());
-        assert!(new_size > 0);
+unsafe impl Alloc for GcAllocator {
+    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
+        let p = alloc(layout, true);
+        Ok(NonNull::new_unchecked(p))
+    }
 
-        AllocMetadata::update(ptr as usize, new_ptr as usize, new_size);
-        new_ptr
+    unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
+        dealloc(ptr.as_ptr(), layout);
+    }
+
+    unsafe fn realloc(
+        &mut self,
+        ptr: NonNull<u8>,
+        layout: Layout,
+        new_size: usize,
+    ) -> Result<NonNull<u8>, AllocErr> {
+        let newptr = realloc(ptr.as_ptr(), layout, new_size);
+        Ok(NonNull::new_unchecked(newptr))
+    }
+}
+
+#[inline]
+unsafe fn alloc(layout: Layout, is_gc: bool) -> *mut u8 {
+    ALLOC_LOCK.lock();
+    let (l2, uoff) = Layout::new::<BlockHeader>().extend(layout).unwrap();
+    let p = System.alloc(l2).add(uoff);
+    let headerptr = (p as *mut BlockHeader).sub(1);
+
+    let header = BlockHeader::new(layout.size(), is_gc);
+    BlockHeader::patch_next(LAST_ALLOCED, headerptr);
+    ::std::ptr::write(headerptr, header);
+    LAST_ALLOCED = headerptr;
+
+    ALLOC_LOCK.unlock();
+    p
+}
+
+#[inline]
+unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
+    ALLOC_LOCK.lock();
+    let (l2, uoff) = Layout::new::<BlockHeader>().extend(layout).unwrap();
+
+    let headerptr = (ptr as *mut BlockHeader).sub(1);
+    let header = ::std::ptr::read(headerptr);
+
+    BlockHeader::patch_next(header.prev, header.next);
+    BlockHeader::patch_prev(header.next, header.prev);
+
+    if headerptr == LAST_ALLOCED {
+        LAST_ALLOCED = header.prev
+    }
+    System.dealloc(ptr.sub(uoff), l2);
+    ALLOC_LOCK.unlock();
+}
+
+#[inline]
+unsafe fn realloc(ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+    ALLOC_LOCK.lock();
+    let old_hp = (ptr as *mut BlockHeader).sub(1);
+    let header = ::std::ptr::read(old_hp);
+
+    let (l2, uoff) = Layout::new::<BlockHeader>().extend(layout).unwrap();
+    let p = System.realloc(ptr.sub(uoff), l2, new_size + uoff).add(uoff);
+
+    let new_hp = (p as *mut BlockHeader).sub(1);
+    header.metadata().size = (new_size as u64).into();
+
+    BlockHeader::patch_next(header.prev, new_hp);
+    BlockHeader::patch_prev(header.next, new_hp);
+    ptr::write(new_hp, header);
+
+    if old_hp == LAST_ALLOCED {
+        LAST_ALLOCED = new_hp
+    }
+    ALLOC_LOCK.unlock();
+
+    p
+}
+
+pub struct BlockHeader {
+    prev: *mut BlockHeader,
+    next: *mut BlockHeader,
+    metadata: [u8; SIZE_BLOCKMETADATA],
+}
+
+const SIZE_BLOCKMETADATA: usize = 16;
+
+#[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
+compile_error!("Requires x86_64 with 64 bit pointer width.");
+#[derive(PackedStruct, Default, Debug)]
+#[packed_struct(bit_numbering = "msb0")]
+pub struct BlockMetadata {
+    /// The size of the block (excluding its header).
+    #[packed_field(size_bits = "62", endian = "msb")]
+    pub(crate) size: Integer<u64, packed_bits::Bits62>,
+    #[packed_field(size_bits = "1")]
+    pub(crate) is_gc: bool,
+    /// Used by the GC during the marking phase.
+    #[packed_field(size_bits = "1")]
+    pub(crate) mark_bit: bool,
+    /// The pointer to the vtable for `Gc<T>`s `Drop` implementation.
+    #[packed_field(size_bits = "63", endian = "msb")]
+    pub(crate) drop_vptr: Integer<u64, packed_bits::Bits63>,
+    /// Has `Drop::drop` been run?
+    #[packed_field(size_bits = "1")]
+    pub(crate) dropped: bool,
+}
+
+impl BlockMetadata {
+    fn new(size: usize, is_gc: bool) -> Self {
+        Self {
+            size: (size as u64).into(),
+            is_gc,
+            mark_bit: false,
+            drop_vptr: (ptr::null_mut::<u8>() as u64).into(),
+            dropped: false,
+        }
+    }
+}
+
+impl BlockHeader {
+    fn new(size: usize, is_gc: bool) -> Self {
+        let metadata = BlockMetadata::new(size, is_gc);
+
+        Self {
+            prev: unsafe { LAST_ALLOCED },
+            next: ptr::null_mut::<BlockHeader>(),
+            metadata: metadata.pack(),
+        }
+    }
+
+    unsafe fn patch_next(header: *mut BlockHeader, next: *mut BlockHeader) {
+        if !header.is_null() {
+            let mut h = ptr::read(header);
+            h.next = next;
+            ptr::write(header, h);
+        }
+    }
+
+    unsafe fn patch_prev(header: *mut BlockHeader, prev: *mut BlockHeader) {
+        if !header.is_null() {
+            let mut h = ptr::read(header);
+            h.prev = prev;
+            ptr::write(header, h);
+        }
+    }
+
+    pub(crate) fn metadata(&self) -> BlockMetadata {
+        BlockMetadata::unpack(&(self.metadata)).unwrap()
+    }
+
+    pub(crate) fn set_metadata(&mut self, metadata: BlockMetadata) {
+        self.metadata = metadata.pack();
     }
 }
 
@@ -65,6 +209,42 @@ impl AllocLock {
 
     fn unlock(&self) {
         self.0.store(false, Ordering::Release);
+    }
+}
+
+impl GlobalAllocator {
+    pub(crate) fn iter(&self) -> BlocksIter {
+        BlocksIter {
+            idx: 0,
+            next: unsafe { LAST_ALLOCED },
+        }
+    }
+}
+
+pub(crate) struct BlocksIter {
+    idx: usize,
+    next: *mut BlockHeader,
+}
+
+impl Iterator for BlocksIter {
+    type Item = PtrInfo;
+
+    fn next(&mut self) -> Option<PtrInfo> {
+        if self.next.is_null() {
+            return None;
+        }
+
+        let header = unsafe { ptr::read(self.next) };
+        let res = Some(PtrInfo {
+            ptr: unsafe { (self.next).add(1) } as usize,
+            size: *header.metadata().size as usize,
+            gc: header.metadata().is_gc,
+        });
+
+        self.idx += 1;
+        self.next = header.prev;
+
+        res
     }
 }
 
@@ -116,6 +296,17 @@ impl<T> VOH<T> {
             let end = self.as_mut_ptr().add(self.len);
             ::std::ptr::write(end, Some(value));
             self.len += 1;
+        }
+    }
+
+    pub fn pop(&mut self) -> Option<T> {
+        if self.len == 0 {
+            None
+        } else {
+            unsafe {
+                self.len -= 1;
+                ptr::read(self.get_unchecked(self.len()))
+            }
         }
     }
 
@@ -186,154 +377,4 @@ pub struct PtrInfo {
     pub size: usize,
     /// Whether the allocation block is managed by the GC or Rust's RAII.
     pub gc: bool,
-}
-
-// -----------------------------------------------------------------------------
-//        APIs for querying the block information about each allocation
-// -----------------------------------------------------------------------------
-
-pub struct AllocMetadata;
-
-impl AllocMetadata {
-    /// Insert metadata about an allocation block. The GC scans for reachable
-    /// objects conservatively. It uses the metadata stored against each
-    /// allocation to determine:
-    /// 1) the size of an allocation block
-    /// 2) whether an allocation block's memory management is the responsibility
-    ///    of the GC
-    /// 3) whether an arbitrary pointer-like word points within an
-    ///    allocation block
-    pub(crate) fn insert(ptr: usize, size: usize, gc: bool) {
-        ALLOC_LOCK.lock();
-        unsafe { BLOCK_METADATA.push(PtrInfo { ptr, size, gc }) };
-        ALLOC_LOCK.unlock();
-    }
-    /// Returns metadata about an allocation block when given an arbitrary
-    /// pointer to the start of the block or an offset within it.
-    pub(crate) fn find(ptr: usize) -> Option<PtrInfo> {
-        ALLOC_LOCK.lock();
-        let block = unsafe {
-            BLOCK_METADATA
-                .iter()
-                .filter_map(|x| *x)
-                .find(|x| ptr >= x.ptr && ptr < x.ptr + x.size)
-        };
-        ALLOC_LOCK.unlock();
-        block
-    }
-
-    /// Updates the metadata associated with an allocation so that the block
-    /// once pointed to by `ptr` is recorded as having moved to `new_ptr` and is
-    /// now `size` bytes big.
-    pub(crate) fn update(ptr: usize, new_ptr: usize, size: usize) {
-        ALLOC_LOCK.lock();
-        unsafe {
-            let idx = BLOCK_METADATA
-                .iter()
-                .position(|x| x.map_or(false, |x| x.ptr == ptr))
-                .unwrap();
-
-            BLOCK_METADATA[idx] = Some(PtrInfo {
-                ptr: new_ptr,
-                size,
-                gc: BLOCK_METADATA[idx].unwrap().gc,
-            });
-        }
-        ALLOC_LOCK.unlock();
-    }
-
-    /// Removes the metadata associated with an allocation.
-    pub(crate) fn remove(ptr: usize) {
-        ALLOC_LOCK.lock();
-        unsafe {
-            let idx = BLOCK_METADATA
-                .iter()
-                .position(|x| x.map_or(false, |x| x.ptr == ptr))
-                .unwrap();
-            BLOCK_METADATA.remove(idx);
-        }
-        ALLOC_LOCK.unlock();
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    static mut NEXT_PTR: usize = 1;
-    static mut PTR_LOCK: AllocLock = AllocLock::new();
-
-    fn unique_ptr(size: usize) -> usize {
-        unsafe {
-            PTR_LOCK.lock();
-            let ptr = NEXT_PTR;
-            NEXT_PTR += size + 1;
-            PTR_LOCK.unlock();
-            ptr
-        }
-    }
-
-    #[test]
-    fn insert_and_find_ptr() {
-        let size = 4;
-        let pi = PtrInfo {
-            ptr: unique_ptr(size),
-            size,
-            gc: false,
-        };
-
-        AllocMetadata::insert(pi.ptr, pi.size, pi.gc);
-        assert_eq!(AllocMetadata::find(pi.ptr).unwrap(), pi)
-    }
-
-    #[test]
-    fn find_inner_ptr() {
-        let size = 2;
-        let pi = PtrInfo {
-            ptr: unique_ptr(size),
-            size,
-            gc: false,
-        };
-        AllocMetadata::insert(pi.ptr, pi.size, pi.gc);
-
-        for i in 0..size {
-            assert_eq!(AllocMetadata::find(pi.ptr + i).unwrap(), pi);
-        }
-
-        // Check for off-by-one
-        match AllocMetadata::find(pi.ptr + size + 1) {
-            Some(pi_actual) => assert_ne!(pi_actual, pi),
-            None => (),
-        }
-    }
-
-    #[test]
-    fn free_block() {
-        let size = 2;
-        let pi = PtrInfo {
-            ptr: unique_ptr(size),
-            size,
-            gc: false,
-        };
-
-        AllocMetadata::insert(pi.ptr, pi.size, pi.gc);
-        assert!(AllocMetadata::find(pi.ptr).is_some());
-        AllocMetadata::remove(pi.ptr);
-
-        assert!(AllocMetadata::find(pi.ptr).is_none());
-    }
-
-    #[test]
-    fn record_gc_alloc() {
-        let size = 2;
-        let pi = PtrInfo {
-            ptr: unique_ptr(size),
-            size,
-            gc: true,
-        };
-
-        AllocMetadata::insert(pi.ptr, pi.size, pi.gc);
-
-        assert!(AllocMetadata::find(pi.ptr).unwrap().gc);
-    }
 }


### PR DESCRIPTION
This PR is going to be a bit difficult to review as it touches every part of the
collector. I've done my best to split the commits chronologically.

During collection, we need a way to traverse each heap allocated block
found from the rootset for further pointers. Previously this was done
using a global vector which stored metadata about each allocation. This
was brittle and lead to synchronisation problems.

This commit adds a header to each block with pointers to next and
previous blocks, allowing them to traversed during collection. A doubly
linked list is used so that deallocation is O(1) instead of O(n).

We also fold the header for GC objects up into the block header.
Although we take a memory hit in doing this with an extra 4 machine
words necessary per each allocation, the implementation is simplified
and easier to debug in the meantime.

