### PR TITLE
Add fully static initialization of collector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 libc = "*"
 packed_struct = "0.3"
 packed_struct_codegen = "0.3"
+parking_lot = { version = "0.10", features = ["nightly"] }
 
 [build-dependencies]
 rerun_except = "0.1"

--- a/gc_tests/tests/collect_runs_drop.rs
+++ b/gc_tests/tests/collect_runs_drop.rs
@@ -16,7 +16,7 @@ impl Drop for IncrOnDrop {
 }
 
 fn main() {
-    gcmalloc::init(DebugFlags::new().mark_phase(false));
+    gcmalloc::debug_flags(DebugFlags::new().mark_phase(false));
 
     Gc::new(IncrOnDrop(123));
 

--- a/gc_tests/tests/cyclic_destructors.rs
+++ b/gc_tests/tests/cyclic_destructors.rs
@@ -40,7 +40,7 @@ fn make_objgraph() -> Gc<Node> {
 }
 
 fn main() {
-    gcmalloc::init(DebugFlags::new().mark_phase(false));
+    gcmalloc::debug_flags(DebugFlags::new().mark_phase(false));
 
     let a = make_objgraph();
     gcmalloc::collect();

--- a/gc_tests/tests/destructors_inner_gc.rs
+++ b/gc_tests/tests/destructors_inner_gc.rs
@@ -18,7 +18,7 @@ impl Drop for IncrOnDrop {
 }
 
 fn main() {
-    gcmalloc::init(DebugFlags::new().mark_phase(false));
+    gcmalloc::debug_flags(DebugFlags::new().mark_phase(false));
 
     let s = HasInnerGc(Gc::new(IncrOnDrop(None)));
     Gc::new(s);

--- a/gc_tests/tests/mark_through_gc_objects.rs
+++ b/gc_tests/tests/mark_through_gc_objects.rs
@@ -40,7 +40,7 @@ fn make_objgraph() -> Box<OnRustHeap> {
 }
 
 fn main() {
-    gcmalloc::init(DebugFlags::new().sweep_phase(false));
+    gcmalloc::debug_flags(DebugFlags::new().sweep_phase(false));
 
     let objgraph = make_objgraph();
     gcmalloc::collect();

--- a/gc_tests/tests/mark_through_std_collections.rs
+++ b/gc_tests/tests/mark_through_std_collections.rs
@@ -22,7 +22,7 @@ fn make_objgraph() -> Vec<GcData> {
 }
 
 fn main() {
-    gcmalloc::init(DebugFlags::new().sweep_phase(false));
+    gcmalloc::debug_flags(DebugFlags::new().sweep_phase(false));
 
     let objgraph = make_objgraph();
     gcmalloc::collect();

--- a/gc_tests/tests/no_drop_live_inner.rs
+++ b/gc_tests/tests/no_drop_live_inner.rs
@@ -20,7 +20,7 @@ impl Drop for IncrOnDrop {
 // This tests that if an inner Gc is kept alive from some reference outside a
 // dying outer Gc, the inner destructor should *not* be ran.
 fn main() {
-    gcmalloc::init(DebugFlags::new().mark_phase(false));
+    gcmalloc::debug_flags(DebugFlags::new().mark_phase(false));
 
     let inner = Gc::new(IncrOnDrop(None));
     unsafe { Debug::keep_alive(inner) };

--- a/gc_tests/tests/on_stack_root_marking.rs
+++ b/gc_tests/tests/on_stack_root_marking.rs
@@ -12,7 +12,7 @@ fn foo() {
 }
 
 fn main() {
-    gcmalloc::init(DebugFlags::new().sweep_phase(false));
+    gcmalloc::debug_flags(DebugFlags::new().sweep_phase(false));
 
     let x = Gc::new(123 as usize);
     foo(); // triggers a collection

--- a/gc_tests/tests/recursive_destructors.rs
+++ b/gc_tests/tests/recursive_destructors.rs
@@ -16,7 +16,7 @@ impl Drop for IncrOnDrop {
 }
 
 fn main() {
-    gcmalloc::init(DebugFlags::new().mark_phase(false));
+    gcmalloc::debug_flags(DebugFlags::new().mark_phase(false));
 
     let s = IncrOnDrop(Some(Box::new(IncrOnDrop(Some(Box::new(IncrOnDrop(None)))))));
     Gc::new(s);

--- a/gc_tests/tests/simple_cyclic_objgraph.rs
+++ b/gc_tests/tests/simple_cyclic_objgraph.rs
@@ -32,7 +32,7 @@ fn make_objgraph() -> Gc<Node> {
 }
 
 fn main() {
-    gcmalloc::init(DebugFlags::new().sweep_phase(false));
+    gcmalloc::debug_flags(DebugFlags::new().sweep_phase(false));
 
     let a = make_objgraph();
     gcmalloc::collect();

--- a/gc_tests/tests/valgrind_basic_memory_reclamation.rs
+++ b/gc_tests/tests/valgrind_basic_memory_reclamation.rs
@@ -25,7 +25,7 @@ struct S {
 }
 
 fn main() {
-    gcmalloc::init(DebugFlags::new().mark_phase(false));
+    gcmalloc::debug_flags(DebugFlags::new().mark_phase(false));
 
     let x = Gc::new(123 as usize);
     let y = Gc::new(S { a: 10, b: 20} );


### PR DESCRIPTION
This should make the GC easier to integrate with existing projects, as
we remove the requirement to manually run `init` in main. Note that we
switch to using the `parking_lot` synchronisation primitives as they
don't require heap-allocation and their constructors are const
functions.