### PR TITLE
Add collector phase for GC preparation & simplify existing phases

### DIFF
--- a/gc_tests/tests/multiple_collections.rs
+++ b/gc_tests/tests/multiple_collections.rs
@@ -1,0 +1,23 @@
+// Run-time:
+//  status: success
+
+extern crate gcmalloc;
+
+use gcmalloc::{collect, gc::DebugFlags, Debug, Gc};
+
+fn main() {
+    let y = Gc::new(456 as usize);
+    collect();
+    assert!(Debug::is_black(y));
+
+    // Enable only the preparation phase, to see if it clears y's mark-bit.
+    gcmalloc::debug_flags(DebugFlags::new().mark_phase(false).sweep_phase(false));
+    collect();
+    assert!(!Debug::is_black(y));
+
+    // Now do a full collection...
+    gcmalloc::debug_flags(DebugFlags::new());
+    collect();
+    // ... and y should still be reachable.
+    assert!(Debug::is_black(y));
+}

--- a/gc_tests/tests/no_drop_live_inner.rs
+++ b/gc_tests/tests/no_drop_live_inner.rs
@@ -20,7 +20,7 @@ impl Drop for IncrOnDrop {
 // This tests that if an inner Gc is kept alive from some reference outside a
 // dying outer Gc, the inner destructor should *not* be ran.
 fn main() {
-    gcmalloc::debug_flags(DebugFlags::new().mark_phase(false));
+    gcmalloc::debug_flags(DebugFlags::new().prep_phase(false).mark_phase(false));
 
     let inner = Gc::new(IncrOnDrop(None));
     unsafe { Debug::keep_alive(inner) };

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -127,7 +127,7 @@ const SIZE_BLOCKMETADATA: usize = 16;
 
 #[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
 compile_error!("Requires x86_64 with 64 bit pointer width.");
-#[derive(PackedStruct, Default, Debug)]
+#[derive(PackedStruct, Debug)]
 #[packed_struct(bit_numbering = "msb0")]
 pub struct BlockMetadata {
     /// The size of the block (excluding its header).
@@ -135,7 +135,7 @@ pub struct BlockMetadata {
     pub(crate) size: Integer<u64, packed_bits::Bits62>,
     #[packed_field(size_bits = "1")]
     pub(crate) is_gc: bool,
-    /// Used by the GC during the marking phase.
+    /// Used by the GC to determine object's reachability.
     #[packed_field(size_bits = "1")]
     pub(crate) mark_bit: bool,
     /// The pointer to the vtable for `Gc<T>`s `Drop` implementation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,11 +210,6 @@ impl Debug {
     /// a collection: mis-identified integer, floating garbage in the red-zone,
     /// stale pointers in registers etc.
     pub fn is_black<T>(gc: Gc<T>) -> bool {
-        // Checking an object's colour only makes sense immediately after
-        // marking has taken place. After a full collection has happened,
-        // marking results are stale and the object graph must be re-marked in
-        // order for this query to be meaningful.
-        assert!(!COLLECTOR.lock().debug_flags.sweep_phase);
         assert_eq!(*COLLECTOR_PHASE.lock(), gc::CollectorPhase::Ready);
 
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod gc;
 
 use crate::{
     alloc::{BlockHeader, BlockMetadata, GcAllocator, GlobalAllocator},
-    gc::{Collector, CollectorState},
+    gc::{Collector, CollectorPhase},
 };
 use std::{
     alloc::{Alloc, Layout},
@@ -36,7 +36,7 @@ static mut GC_ALLOCATOR: GcAllocator = GcAllocator;
 
 static COLLECTOR: Mutex<Collector> = Mutex::new(Collector::new());
 
-static COLLECTOR_STATE: Mutex<CollectorState> = Mutex::new(CollectorState::Ready);
+static COLLECTOR_PHASE: Mutex<CollectorPhase> = Mutex::new(CollectorPhase::Ready);
 
 /// A garbage collected pointer. 'Gc' stands for 'Garbage collected'.
 ///
@@ -215,7 +215,7 @@ impl Debug {
         // marking results are stale and the object graph must be re-marked in
         // order for this query to be meaningful.
         assert!(!COLLECTOR.lock().debug_flags.sweep_phase);
-        assert_eq!(*COLLECTOR_STATE.lock(), gc::CollectorState::Ready);
+        assert_eq!(*COLLECTOR_PHASE.lock(), gc::CollectorPhase::Ready);
 
         unsafe {
             return COLLECTOR


### PR DESCRIPTION
It turns out that with the benefit of hindsight, things are greatly simplified
if resetting mark bits is a distinct phase which takes place before marking. Not
only does this let us de-couple the collector from much of the Gc and alloc
APIs, but we also no longer need to lock the collector on each fresh `Gc::new()`
to see which state represents black.

I've also been using phase / state interchangeably when referring to the various
parts of a collection. From now on, I'm stricter about terminology and refer to
them as phases.
