### PR TITLE
Add a basic allocation counter to trigger GC

### DIFF
--- a/gc_tests/tests/auto_collection.rs
+++ b/gc_tests/tests/auto_collection.rs
@@ -1,0 +1,21 @@
+// Run-time:
+//  status: success
+
+extern crate gcmalloc;
+
+use gcmalloc::{collect, gc::DebugFlags, Debug, Gc};
+
+fn main() {
+    let threshold = 5;
+    // Lower the threshold so that the test doesn't take forever.
+    gcmalloc::set_threshold(threshold);
+
+    let x = Gc::new("Hello World".to_string());
+    assert!(!Debug::is_black(x));
+
+    for i in 0..threshold {
+        let x = Gc::new(123 as usize);
+    }
+
+    assert!(Debug::is_black(x));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@ static COLLECTOR: Mutex<Collector> = Mutex::new(Collector::new());
 
 static COLLECTOR_PHASE: Mutex<CollectorPhase> = Mutex::new(CollectorPhase::Ready);
 
+/// The default number of GC values allocated before a collection is triggered.
+const GC_ALLOCATION_THRESHOLD: usize = 100;
+
 /// A garbage collected pointer. 'Gc' stands for 'Garbage collected'.
 ///
 /// The type `Gc<T>` provides shared ownership of a value of type `T`,
@@ -215,6 +218,10 @@ pub fn collect() {
 
 pub fn debug_flags(flags: gc::DebugFlags) {
     COLLECTOR.lock().debug_flags = flags;
+}
+
+pub fn set_threshold(threshold: usize) {
+    COLLECTOR.lock().allocation_threshold = threshold
 }
 
 /// Provides some useful functions for debugging and testing the collector.


### PR DESCRIPTION
Until now, garbage collection could only be triggered manually (via
`gcmalloc::collect()`). This adds a simple counter which increments on
the allocation of new `Gc` values until a threshold has been reached.
This arbitrarily defaults to 100 `Gc` values.