### PR TITLE
Keep Gc value alive if pointed to by one-element-after ptr

### DIFF
--- a/gc_tests/tests/auto_collection.rs
+++ b/gc_tests/tests/auto_collection.rs
@@ -11,11 +11,11 @@ fn main() {
     gcmalloc::set_threshold(threshold);
 
     let x = Gc::new("Hello World".to_string());
-    assert!(!Debug::is_black(x));
+    assert!(!Debug::is_black(x.as_ptr() as *mut String as *mut u8));
 
     for i in 0..threshold {
         let x = Gc::new(123 as usize);
     }
 
-    assert!(Debug::is_black(x));
+    assert!(Debug::is_black(x.as_ptr() as *mut String as *mut u8));
 }

--- a/gc_tests/tests/c_pointer_after.rs
+++ b/gc_tests/tests/c_pointer_after.rs
@@ -1,0 +1,34 @@
+// Run-time:
+//  status: success
+
+extern crate gcmalloc;
+
+use gcmalloc::{collect, gc::DebugFlags, Debug, Gc};
+
+#[inline(never)]
+fn setup_obj() -> Box<*mut u8> {
+    let a = Gc::new(123_u8);
+
+    // Return a pointer to 1 byte past the end of the value. This is valid in
+    // the C (and Rust) standard, so it should keep the object alive.
+    //
+    // We box it to prevent the original pointer rooting the object through a
+    // stale register across the call
+    Box::new(unsafe { a.as_ptr().add(1) as *mut u8 })
+}
+
+#[inline(never)]
+fn check_marked(ptr: Box<*mut u8>) {
+    // Reconstruct the base pointer to see if it was marked
+    let base = unsafe { (*ptr).sub(1) as *mut u8 };
+    assert!(Debug::is_black(base));
+}
+
+fn main() {
+    gcmalloc::debug_flags(DebugFlags::new().sweep_phase(false));
+
+    let a = setup_obj();
+    collect();
+
+    check_marked(a);
+}

--- a/gc_tests/tests/mark_through_gc_objects.rs
+++ b/gc_tests/tests/mark_through_gc_objects.rs
@@ -48,6 +48,6 @@ fn main() {
     let x = objgraph.a.unwrap().b;
     let y = objgraph.b;
 
-    assert!(Debug::is_black(x));
-    assert!(Debug::is_black(y));
+    assert!(Debug::is_black(x.as_ptr() as *mut u8));
+    assert!(Debug::is_black(y.as_ptr() as *mut u8));
 }

--- a/gc_tests/tests/multiple_collections.rs
+++ b/gc_tests/tests/multiple_collections.rs
@@ -8,16 +8,16 @@ use gcmalloc::{collect, gc::DebugFlags, Debug, Gc};
 fn main() {
     let y = Gc::new(456 as usize);
     collect();
-    assert!(Debug::is_black(y));
+    assert!(Debug::is_black(y.as_ptr() as *mut u8));
 
     // Enable only the preparation phase, to see if it clears y's mark-bit.
     gcmalloc::debug_flags(DebugFlags::new().mark_phase(false).sweep_phase(false));
     collect();
-    assert!(!Debug::is_black(y));
+    assert!(!Debug::is_black(y.as_ptr() as *mut u8));
 
     // Now do a full collection...
     gcmalloc::debug_flags(DebugFlags::new());
     collect();
     // ... and y should still be reachable.
-    assert!(Debug::is_black(y));
+    assert!(Debug::is_black(y.as_ptr() as *mut u8));
 }

--- a/gc_tests/tests/on_stack_root_marking.rs
+++ b/gc_tests/tests/on_stack_root_marking.rs
@@ -8,7 +8,7 @@ use gcmalloc::{collect, gc::DebugFlags, Debug, Gc};
 fn foo() {
     let y = Gc::new(456 as usize);
     collect();
-    assert!(Debug::is_black(y));
+    assert!(Debug::is_black(y.as_ptr() as *mut u8));
 }
 
 fn main() {
@@ -16,5 +16,5 @@ fn main() {
 
     let x = Gc::new(123 as usize);
     foo(); // triggers a collection
-    assert!(Debug::is_black(x));
+    assert!(Debug::is_black(x.as_ptr() as *mut u8));
 }

--- a/gc_tests/tests/simple_cyclic_objgraph.rs
+++ b/gc_tests/tests/simple_cyclic_objgraph.rs
@@ -39,20 +39,24 @@ fn main() {
 
     // Test a
     assert_eq!(a.data, String::from("a"));
-    assert!(Debug::is_black(a));
+    assert!(Debug::is_black(a.as_ptr() as *mut u8));
 
     // Test b
     assert_eq!(a.edge.unwrap().data, String::from("b"));
-    assert!(Debug::is_black(a.edge.unwrap()));
+    assert!(Debug::is_black(a.edge.unwrap().as_ptr() as *mut u8));
 
     // Test c
     assert_eq!(a.edge.unwrap().edge.unwrap().data, String::from("c"));
-    assert!(Debug::is_black(a.edge.unwrap().edge.unwrap()));
+    assert!(Debug::is_black(
+        a.edge.unwrap().edge.unwrap().as_ptr() as *mut u8
+    ));
 
     // Test c -> a
     assert_eq!(
         a.edge.unwrap().edge.unwrap().edge.unwrap().data,
         String::from("a")
     );
-    assert!(Debug::is_black(a.edge.unwrap().edge.unwrap().edge.unwrap()));
+    assert!(Debug::is_black(
+        a.edge.unwrap().edge.unwrap().edge.unwrap().as_ptr() as *mut u8
+    ));
 }

--- a/gc_tests/tests/static_roots.rs
+++ b/gc_tests/tests/static_roots.rs
@@ -24,5 +24,5 @@ fn main() {
     setup_root();
 
     gcmalloc::collect();
-    unsafe {assert!(Debug::is_black(SOME_ROOT.unwrap())) };
+    unsafe {assert!(Debug::is_black(SOME_ROOT.unwrap().as_ptr() as *mut u8)) };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,10 +236,10 @@ impl Debug {
     /// non-deterministic reasons that an unreachable object might still survive
     /// a collection: mis-identified integer, floating garbage in the red-zone,
     /// stale pointers in registers etc.
-    pub fn is_black<T>(gc: Gc<T>) -> bool {
+    pub fn is_black<T>(gc: *mut T) -> bool {
         assert_eq!(*COLLECTOR_PHASE.lock(), gc::CollectorPhase::Ready);
 
-        let obj = unsafe { &*(gc.objptr as *const GcBox<gc::OpaqueU8>) };
+        let obj = unsafe { &*(gc as *const GcBox<gc::OpaqueU8>) };
         obj.colour() == Colour::Black
     }
 


### PR DESCRIPTION
Rust (and C) allow pointers 1 byte after the end of an array providing
it is never dereferenced. The GC must take this into account and keep
values with one-element-after pointers alive.