### PR TITLE
Make `Gc` store a `NonNull` pointer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ impl Debug {
     }
 
     pub unsafe fn keep_alive<T>(gc: Gc<T>) {
-        let obj = &mut *(gc.objptr as *mut GcBox<OpaqueU8>);
+        let obj = &mut *(gc.objptr.as_ptr() as *mut GcBox<OpaqueU8>);
         obj.set_colour(Colour::Black)
     }
 }


### PR DESCRIPTION
This makes `Option<Gc>` a machine word rather than two machine words
big, which is a useful optimisation.