### PR TITLE
Fix bug where realloc did not update block size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ libc = "*"
 packed_struct = "0.3"
 packed_struct_codegen = "0.3"
 parking_lot = { version = "0.10", features = ["nightly"] }
+static_assertions = "1.1"
 
 [build-dependencies]
 rerun_except = "0.1"

--- a/gc_tests/tests/mark_through_std_collections.rs
+++ b/gc_tests/tests/mark_through_std_collections.rs
@@ -1,36 +1,32 @@
+// Run-time:
+//  status: success
+
 extern crate gcmalloc;
 
 use gcmalloc::{collect, DebugFlags, Debug, Gc};
 
 struct GcData {
     a: Gc<usize>,
-    b: Gc<Gc<usize>>,
+    b: Gc<usize>,
 }
 
 impl GcData {
-    fn new(a: Gc<usize>, b: Gc<Gc<usize>>) -> Self {
+    fn new(a: Gc<usize>, b: Gc<usize>) -> Self {
         Self { a, b }
     }
-}
-
-fn make_objgraph() -> Vec<GcData> {
-    let mut gcs = Vec::new();
-    for i in 1..1000 {
-        gcs.push(GcData::new(Gc::new(i), Gc::new(Gc::new(1))))
-    }
-    gcs
 }
 
 fn main() {
     gcmalloc::debug_flags(DebugFlags::new().sweep_phase(false));
 
-    let objgraph = make_objgraph();
+    let mut gcs = Vec::new();
+    for i in 1..100 {
+        gcs.push(Gc::new(i))
+    }
+
     gcmalloc::collect();
 
-    // for gcdata in objgraph.iter() {
-    //     for i in gcdata.b.iter() {
-    //         assert!(Debug::is_black(*i));
-    //     }
-    //     // assert!(Debug::is_black(gcdata.a));
-    // }
+    for gc in gcs.iter() {
+        assert!(Debug::is_black(gc.as_ptr() as *mut u8));
+    }
 }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -321,7 +321,7 @@ impl Collector {
 
         for stack_address in (rsp..stack_top).step_by(WORD_SIZE) {
             let stack_word = unsafe { *(stack_address as *const Word) };
-            self.check_pointer(stack_word)
+            self.check_pointer(stack_word);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@ extern crate packed_struct;
 #[macro_use]
 extern crate packed_struct_codegen;
 
+#[macro_use]
+extern crate static_assertions;
+
 pub mod allocator;
 pub mod collector;
 pub mod gc;


### PR DESCRIPTION
This caused the contents of vectors not to be fully traced if their
capacity grew over time, leading to the freeing of live objects. Also
simplify the test for this and ensure it is no longer ignored.