### PR TITLE
Use `Block` in collector with proper move semantics

### DIFF
--- a/src/gc.rs
+++ b/src/gc.rs
@@ -132,10 +132,6 @@ impl<T: ?Sized> GcBox<T> {
         self.block().set_drop_vptr(value);
     }
 
-    pub(crate) fn drop_vptr(&self) -> *mut u8 {
-        self.block().drop_vptr()
-    }
-
     pub(crate) fn dropped(&self) -> bool {
         self.block().dropped()
     }


### PR DESCRIPTION
Previously, we used a struct called `PtrInfo` which held some
information about each block for various methods in the `Collector`.
`PtrInfo` was copyable, had public fields, and allowed us to retain
information about a block within the `Collector` methods even after they
had been freed. This was very unsafe as derefs to block pointers within
the collector were all based on hidden assumptions about how the GC
algorithm worked.

This commit attempts to minimise this unsafety by using move semantics
and information hiding to ensure the following when accessing blocks
within the Collector methods:

     

-  The actual block pointer is hidden from the collector, this
    prevents it from being derefed unless done through restricted
    APIs on the `Block` interface. When the collector needs to perform
    pointer comparisons with arbitrary words, these words are instead
    passed to the block with the result returned to the collector.

- The `Block` pointer interface is no longer copy/cloneable, which
    means that destructive operations such as `drop` can consume the `Block`
    to help prevent it being used later in the collector.