### PR TITLE
Encapsulate unsafe heap access through explicit references on Block API.

### DIFF
--- a/gc_tests/valgrind.supp
+++ b/gc_tests/valgrind.supp
@@ -2,6 +2,6 @@
    <uninitialized_stack>
    Memcheck:Cond
    ...
-   fun:_ZN8gcmalloc9collector9Collector13check_pointer*
+   fun:_ZN8gcmalloc9allocator5Block4find*
 }
 

--- a/src/SpillRegisters_X64.S
+++ b/src/SpillRegisters_X64.S
@@ -18,11 +18,11 @@ spill_registers:
     push %r13
     push %r14
     push %r15
-    // %rdi already contains the 'self' reference to the collector. We move the
-    // function pointer in %rsi to %r8 (a scratch register) so that the stack
-    // pointer can be placed in %rdi as the first arg slot.
-    mov %rsi, %r8
-    mov %rsp, %rsi
+    // %rdi contains the function pointer to our stack scanning code. We move it
+    // to %r8 (a scratch register) so that the stack pointer can be placed in
+    // %rdi as the first arg slot.
+    mov %rdi, %r8
+    mov %rsp, %rdi
     call *%r8
     // Pop all the callee-save registers (ret will pop the return addr)
     add $56, %rsp

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -1,5 +1,5 @@
 use crate::{
-    allocator::{Block, GcVec, HEAP_TOP},
+    allocator::{Block, GcVec},
     gc::Colour,
     ALLOCATOR, COLLECTOR_PHASE, GC_ALLOCATION_THRESHOLD,
 };
@@ -15,14 +15,14 @@ type Word = usize;
 /// bytes.
 pub(crate) struct OpaqueU8(u8);
 
-type StackScanCallback = unsafe extern "sysv64" fn(*mut Collector, Address);
+type StackScanCallback = unsafe extern "sysv64" fn(Address, *mut MarkingCtxt);
 #[link(name = "SpillRegisters", kind = "static")]
 extern "sysv64" {
     // Pass a type-punned pointer to the collector and move it to the asm spill
     // code. This is so it can be passed straight back as the implicit `self`
     // address in the callback.
     #[allow(improper_ctypes)]
-    fn spill_registers(collector: *mut u8, callback: StackScanCallback);
+    fn spill_registers(callback: StackScanCallback, ctxt: *mut MarkingCtxt);
 }
 
 /// Used to denote which phase the collector is in at a given point in time.
@@ -88,6 +88,13 @@ impl DebugFlags {
     }
 }
 
+pub(crate) struct MarkingCtxt<'mrk> {
+    pub(crate) worklist: GcVec<Block<'mrk>>,
+    pub(crate) stack_start: usize,
+    pub(crate) data_segment_start: usize,
+    pub(crate) data_segment_end: usize,
+}
+
 /// A collector responsible for finding and freeing unreachable objects.
 ///
 /// It is implemented as a stop-the-world, conservative, mark-sweep GC. A full
@@ -114,14 +121,9 @@ impl DebugFlags {
 ///
 /// During a collection, each phase is run consecutively and requires all
 /// mutator threads to come to a complete stop.
-pub(crate) struct Collector<'a> {
-    /// Used during the mark phase. The marking worklist consists of allocation
-    /// blocks which still need tracing. Once the worklist is empty, the marking
-    /// phase is complete, and the full object-graph has been traversed.
-    worklist: GcVec<Block<'a>>,
-
+pub(crate) struct Collector {
     /// Holds pointers to unreachable blocks awaiting destruction.
-    drop_queue: GcVec<Block<'a>>,
+    drop_queue: GcVec<Block<'static>>,
 
     /// Flags used to turn on/off certain collection phases for debugging &
     /// testing purposes.
@@ -132,25 +134,15 @@ pub(crate) struct Collector<'a> {
 
     /// The number of GC values allocated since the last collection.
     pub(crate) allocations: usize,
-
-    /// The data segment houses statics and consts, the former can contain roots
-    /// so the entire segment needs scanning during collection. The range bounds
-    /// are always word aligned addresses from low to high.
-    data_segment_start: usize,
-    data_segment_end: usize,
 }
 
-impl<'a> Collector<'a> {
+impl Collector {
     pub(crate) const fn new() -> Self {
         Self {
-            worklist: GcVec::new(),
             drop_queue: GcVec::new(),
             debug_flags: DebugFlags::new(),
             allocation_threshold: GC_ALLOCATION_THRESHOLD,
             allocations: 0,
-
-            data_segment_start: 0,
-            data_segment_end: 0,
         }
     }
 
@@ -170,19 +162,7 @@ impl<'a> Collector<'a> {
             self.enter_preparation_phase();
         }
 
-        if self.data_segment_start == 0 || self.data_segment_end == 0 {
-            let (s, e) = unsafe { get_data_segment_range() };
-            self.data_segment_start = s;
-            self.data_segment_end = e;
-        }
-
         COLLECTOR_PHASE.lock().update(CollectorPhase::Marking);
-
-        // Register spilling is platform specific. This is implemented in
-        // an assembly stub. The fn to scan the stack is passed as a callback
-        unsafe { spill_registers(self as *mut Collector as *mut u8, Collector::scan_stack) }
-
-        self.scan_statics();
 
         if self.debug_flags.mark_phase {
             self.enter_mark_phase();
@@ -219,11 +199,30 @@ impl<'a> Collector<'a> {
     /// The mark phase colours blocks in the worklist which are managed by the
     /// collector. It also traverses the contents of **all** blocks for further
     /// pointers.
-    fn enter_mark_phase(&mut self) {
+    fn enter_mark_phase<'mrk>(&mut self) {
         COLLECTOR_PHASE.lock().update(CollectorPhase::Marking);
 
-        while !self.worklist.is_empty() {
-            let mut block = self.worklist.pop().unwrap();
+        let stack_start = unsafe { get_stack_start().unwrap() };
+        let (data_segment_start, data_segment_end) = unsafe { get_data_segment_range() };
+
+        let mut ctxt = MarkingCtxt {
+            worklist: GcVec::new(),
+            stack_start,
+            data_segment_start,
+            data_segment_end,
+        };
+
+        // Register spilling is platform specific. This is implemented in
+        // an assembly stub. The fn to scan the stack is passed as a callback
+        unsafe { spill_registers(Collector::scan_stack, &mut ctxt) }
+
+        self.scan_statics(&mut ctxt);
+        self.mark_objects(&mut ctxt);
+    }
+
+    fn mark_objects<'mrk>(&mut self, ctxt: &mut MarkingCtxt<'mrk>) {
+        while !ctxt.worklist.is_empty() {
+            let mut block = ctxt.worklist.pop().unwrap();
             let md = block.header().metadata();
 
             if md.is_gc {
@@ -236,7 +235,9 @@ impl<'a> Collector<'a> {
             // Check each word in the allocation block for pointers.
             for addr in block.range().step_by(WORD_SIZE) {
                 let word = unsafe { *(addr as *const Word) };
-                self.check_pointer(word);
+                if let Some(block) = Block::find(word, ctxt) {
+                    ctxt.worklist.push(block)
+                }
             }
         }
     }
@@ -280,38 +281,25 @@ impl<'a> Collector<'a> {
     /// assembly stub which is expected to get the contents of the stack pointer
     /// and spill all registers which may contain roots.
     #[no_mangle]
-    unsafe extern "sysv64" fn scan_stack(collector: *mut Collector, rsp: Address) {
-        let c = &mut *collector;
-        let stack_top = get_stack_start().unwrap();
+    unsafe extern "sysv64" fn scan_stack<'mrk>(rsp: Address, ctxt: *mut MarkingCtxt<'mrk>) {
+        let ctxt = &mut *ctxt;
 
-        for stack_address in (rsp..stack_top).step_by(WORD_SIZE) {
+        for stack_address in (rsp..ctxt.stack_start).step_by(WORD_SIZE) {
             let stack_word = *(stack_address as *const Word);
-            c.check_pointer(stack_word);
+            if let Some(block) = Block::find(stack_word, ctxt) {
+                ctxt.worklist.push(block)
+            }
         }
     }
 
     /// Roots can hide inside static variables, so these need scanning for
     /// potential pointers too.
     #[cfg(target_os = "linux")]
-    fn scan_statics(&mut self) {
-        for data_addr in (self.data_segment_start..self.data_segment_end).step_by(WORD_SIZE) {
+    fn scan_statics<'mrk>(&mut self, ctxt: &mut MarkingCtxt<'mrk>) {
+        for data_addr in (ctxt.data_segment_start..ctxt.data_segment_end).step_by(WORD_SIZE) {
             let static_word = unsafe { *(data_addr as *const Word) };
-            self.check_pointer(static_word);
-        }
-    }
-
-    fn check_pointer(&mut self, word: Word) {
-        // Since the heap starts at the end of the data segment, we can use this
-        // as the lower heap bound.
-        if word >= self.data_segment_end && word <= unsafe { HEAP_TOP } {
-            if let Some(block) = ALLOCATOR
-                .iter()
-                // It's legal to hold a pointer 1 byte past the end of a block,
-                // but we can still use find because this will never over-run
-                // the size of the next block's header.
-                .find(|x| x.in_bounds(word))
-            {
-                self.worklist.push(block);
+            if let Some(block) = Block::find(static_word, ctxt) {
+                ctxt.worklist.push(block)
             }
         }
     }


### PR DESCRIPTION
This PR attempts to make the `Collector` more ergonomic by using mostly
Rust references to heap blocks inside the Collector methods. Previously we 
were quite liberal in our use of raw pointers in the `Collector` methods. The only 
thing ensuring that these pointers were used correctly were following the 
invariants of a mark-sweep algorithm. These existed mostly in my
head (and of course, I had got this wrong in a few places!)

By using references with explicit lifetimes in this way, we can reduce exposing
raw pointers in the collector and try and put some of the burden of ensuring
correct usage on the borrow-checker. Part of the reason we need to be so
thorough with this is because it is completely UB to hold an invalid reference
in Rust (null, out-of-bounds, etc).

Please see each commit message for more details.

@vext01 I've added you as a reviewer as you may be interested because we
discussed this on Tuesday.
