### PR TITLE
Cache heap block pointers across a collection

### DIFF
--- a/gc_tests/valgrind.supp
+++ b/gc_tests/valgrind.supp
@@ -2,6 +2,5 @@
    <uninitialized_stack>
    Memcheck:Cond
    ...
-   fun:_ZN8gcmalloc9allocator5Block4find*
+   fun:_ZN8gcmalloc9collector14CollectionCtxt4find*
 }
-

--- a/src/SpillRegisters_X64.S
+++ b/src/SpillRegisters_X64.S
@@ -18,11 +18,11 @@ spill_registers:
     push %r13
     push %r14
     push %r15
-    // %rdi contains the function pointer to our stack scanning code. We move it
-    // to %r8 (a scratch register) so that the stack pointer can be placed in
-    // %rdi as the first arg slot.
-    mov %rdi, %r8
-    mov %rsp, %rdi
+    // %rsi contains the function pointer to our stack scanning code. We move it
+    // to %r8 (a scratch register) so that the marking context pointer can be
+    // placed in %rdi as the first arg slot.
+    mov %rsi, %r8
+    mov %rsp, %rsi
     call *%r8
     // Pop all the callee-save registers (ret will pop the return addr)
     add $56, %rsp

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -164,11 +164,8 @@ pub struct BlockMetadata {
     #[packed_field(size_bits = "1")]
     pub(crate) mark_bit: bool,
     /// The pointer to the vtable for `Gc<T>`s `Drop` implementation.
-    #[packed_field(size_bits = "63", endian = "msb")]
+    #[packed_field(size_bits = "64", endian = "msb")]
     pub(crate) drop_vptr: Integer<u64, packed_bits::Bits63>,
-    /// Has `Drop::drop` been run?
-    #[packed_field(size_bits = "1")]
-    pub(crate) dropped: bool,
 }
 
 impl BlockMetadata {
@@ -178,7 +175,6 @@ impl BlockMetadata {
             is_gc,
             mark_bit: false,
             drop_vptr: (ptr::null_mut::<u8>() as u64).into(),
-            dropped: false,
         }
     }
 }
@@ -294,16 +290,6 @@ impl<'a> Block<'a> {
             Colour::Black => md.mark_bit = true,
             Colour::White => md.mark_bit = false,
         }
-        self.header_mut().set_metadata(md);
-    }
-
-    pub(crate) fn dropped(&self) -> bool {
-        self.header().metadata().dropped
-    }
-
-    pub(crate) fn set_dropped(&mut self, value: bool) {
-        let mut md = self.header().metadata();
-        md.dropped = value.into();
         self.header_mut().set_metadata(md);
     }
 

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -8,7 +8,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use crate::{collector::MarkingCtxt, gc::Colour, ALLOCATOR, COLLECTOR};
+use crate::{gc::Colour, ALLOCATOR, COLLECTOR};
 
 use packed_struct::prelude::*;
 
@@ -250,23 +250,6 @@ impl<'a> Block<'a> {
         ::std::ops::Range { start, end }
     }
 
-    pub(crate) fn find<'mrk>(word: usize, ctxt: &MarkingCtxt<'mrk>) -> Option<Block<'mrk>> {
-        // Since the heap starts at the end of the data segment, we can use this
-        // as the lower heap bound.
-        if word >= ctxt.data_segment_end && word <= unsafe { HEAP_TOP } {
-            ALLOCATOR.iter()
-                // It's legal to hold a pointer 1 byte past the end of a block,
-                // but we can still use find because this will never over-run
-                // the size of the next block's header.
-                .find(|x| {
-                    let addr = x.base as usize;
-                    word == addr || word > addr && word <= addr + *x.header().metadata().size as usize
-                })
-        } else {
-            None
-        }
-    }
-
     pub(crate) fn header(&self) -> &BlockHeader {
         unsafe { &*(self.base as *const Block as *const BlockHeader).sub(1) }
     }
@@ -341,6 +324,39 @@ impl AllocLock {
     }
 }
 
+pub(crate) struct AllocCache<'a>(GcVec<Block<'a>>);
+
+impl<'a> AllocCache<'a> {
+    pub(crate) fn find(&self, word: usize) -> Option<Block<'a>> {
+        match self.binary_search_by(|x| {
+            if x.base as usize + ((*x.header().metadata().size) as usize) < word {
+                ::std::cmp::Ordering::Less
+            } else if x.base as usize > word {
+                ::std::cmp::Ordering::Greater
+            } else {
+                ::std::cmp::Ordering::Equal
+            }
+        }) {
+            Ok(i) => return Some(Block::new(self.0[i].base)),
+            Err(_) => return None,
+        }
+    }
+}
+
+impl<'a> ::std::ops::Deref for AllocCache<'a> {
+    type Target = GcVec<Block<'a>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a> ::std::ops::DerefMut for AllocCache<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl GlobalAllocator {
     pub(crate) fn iter(&self) -> BlocksIter {
         BlocksIter {
@@ -348,6 +364,19 @@ impl GlobalAllocator {
             next: unsafe { LAST_ALLOCED },
             _lifetime: PhantomData,
         }
+    }
+
+    pub(crate) fn sorted_cache<'a>(&self) -> AllocCache {
+        // This must be unstable as stable sorting allocates, which means we end
+        // up with 0s at the end of our sorted list because the temporary data
+        // structure's metadata will inserted and then cleared.
+
+        let mut cache = GcVec::new();
+        for block in ALLOCATOR.iter() {
+            cache.push(block);
+        }
+        cache.sort_unstable_by_key(|x| x.base);
+        AllocCache(cache)
     }
 }
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -88,9 +88,17 @@ impl DebugFlags {
     }
 }
 
+/// Holds information needed for the mark phase of GC
 pub(crate) struct MarkingCtxt<'mrk> {
+    /// The worklist holds references to heap blocks which were identified by
+    /// potential pointers somewhere in the object graph. During marking, the
+    /// entire worklist is traversed in order for a full transitive closure over
+    /// the object graph to be performed.
     pub(crate) worklist: GcVec<Block<'mrk>>,
+    /// The top (or start) of the current thread's stack.
     pub(crate) stack_start: usize,
+    /// The data segment of an ELF binary contains statics. This section needs
+    /// scanning during marking as it could contain GC roots.
     pub(crate) data_segment_start: usize,
     pub(crate) data_segment_end: usize,
 }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -10,11 +10,6 @@ type Address = usize;
 
 type Word = usize;
 
-/// Use this type when we do not care about the contents of a Gc. We choose `u8`
-/// because it maps similarly to how C / C++ use char when dealing with raw
-/// bytes.
-pub(crate) struct OpaqueU8(u8);
-
 type StackScanCallback = unsafe extern "sysv64" fn(Address, *mut MarkingCtxt);
 #[link(name = "SpillRegisters", kind = "static")]
 extern "sysv64" {

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -1,5 +1,5 @@
 use crate::{
-    allocator::{Block, GcVec},
+    allocator::{AllocCache, Block, GcVec, HEAP_TOP},
     gc::Colour,
     ALLOCATOR, COLLECTOR_PHASE, GC_ALLOCATION_THRESHOLD,
 };
@@ -9,16 +9,6 @@ static WORD_SIZE: usize = std::mem::size_of::<usize>(); // in bytes
 type Address = usize;
 
 type Word = usize;
-
-type StackScanCallback = unsafe extern "sysv64" fn(Address, *mut MarkingCtxt);
-#[link(name = "SpillRegisters", kind = "static")]
-extern "sysv64" {
-    // Pass a type-punned pointer to the collector and move it to the asm spill
-    // code. This is so it can be passed straight back as the implicit `self`
-    // address in the callback.
-    #[allow(improper_ctypes)]
-    fn spill_registers(callback: StackScanCallback, ctxt: *mut MarkingCtxt);
-}
 
 /// Used to denote which phase the collector is in at a given point in time.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -83,8 +73,31 @@ impl DebugFlags {
     }
 }
 
+/// Contains data expected to last for the duration of a single collection
+/// cycle.
+struct CollectionCtxt<'a> {
+    /// The allocation cache is a freeze-frame of all block pointers in-use by
+    /// the mutator. It is a sorted vector which allows for fast pointer
+    /// identification using binary search. It is valid up until the drop_phase
+    /// of a collection.
+    allocation_cache: AllocCache<'a>,
+    /// The data segment of an ELF binary contains statics. This section needs
+    /// scanning during marking as it could contain GC roots.
+    pub(crate) data_segment_start: usize,
+    pub(crate) data_segment_end: usize,
+}
+
+impl<'a> CollectionCtxt<'a> {
+    pub(crate) fn find(&mut self, word: usize) -> Option<Block<'a>> {
+        if !(word >= self.data_segment_end && word <= unsafe { HEAP_TOP }) {
+            return None;
+        }
+        self.allocation_cache.find(word)
+    }
+}
+
 /// Holds information needed for the mark phase of GC
-pub(crate) struct MarkingCtxt<'mrk> {
+pub(crate) struct MarkingCtxt<'mrk, 'col: 'mrk> {
     /// The worklist holds references to heap blocks which were identified by
     /// potential pointers somewhere in the object graph. During marking, the
     /// entire worklist is traversed in order for a full transitive closure over
@@ -92,10 +105,81 @@ pub(crate) struct MarkingCtxt<'mrk> {
     pub(crate) worklist: GcVec<Block<'mrk>>,
     /// The top (or start) of the current thread's stack.
     pub(crate) stack_start: usize,
-    /// The data segment of an ELF binary contains statics. This section needs
-    /// scanning during marking as it could contain GC roots.
-    pub(crate) data_segment_start: usize,
-    pub(crate) data_segment_end: usize,
+    collection_ctxt: &'mrk mut CollectionCtxt<'col>,
+}
+
+type StackScanCallback = unsafe extern "sysv64" fn(*mut MarkingCtxt, Address);
+#[link(name = "SpillRegisters", kind = "static")]
+extern "sysv64" {
+    // Pass a type-punned pointer to the collector and move it to the asm spill
+    // code. This is so it can be passed straight back as the implicit `self`
+    // address in the callback.
+    #[allow(improper_ctypes)]
+    fn spill_registers(ctxt: *mut MarkingCtxt, callback: StackScanCallback);
+}
+
+impl<'mrk, 'col> MarkingCtxt<'mrk, 'col> {
+    /// Scans the stack from bottom to top, starting from the position of the
+    /// current stack pointer. This method should never be called directly.
+    /// Instead, it should be invoked as a callback from a platform specific
+    /// assembly stub which is expected to get the contents of the stack pointer
+    /// and spill all registers which may contain roots.
+    #[no_mangle]
+    unsafe extern "sysv64" fn scan_stack(ctxt: *mut MarkingCtxt, rsp: Address) {
+        let ctxt = &mut *ctxt;
+        for stack_address in (rsp..ctxt.stack_start).step_by(WORD_SIZE) {
+            let stack_word = *(stack_address as *const Word);
+            if let Some(block) = ctxt.collection_ctxt.find(stack_word) {
+                ctxt.worklist.push(block)
+            }
+        }
+    }
+
+    fn mark(&mut self) {
+        // Register spilling is platform specific. This is implemented in
+        // an assembly stub, with scan_stack passed as a callback.
+        unsafe { spill_registers(self, MarkingCtxt::scan_stack) }
+
+        self.scan_statics();
+        self.process_worklist();
+    }
+
+    /// Roots can hide inside static variables, so these need scanning for
+    /// potential pointers too.
+    #[cfg(target_os = "linux")]
+    fn scan_statics(&mut self) {
+        for data_addr in (self.collection_ctxt.data_segment_start
+            ..self.collection_ctxt.data_segment_end)
+            .step_by(WORD_SIZE)
+        {
+            let static_word = unsafe { *(data_addr as *const Word) };
+            if let Some(block) = self.collection_ctxt.find(static_word) {
+                self.worklist.push(block)
+            }
+        }
+    }
+
+    fn process_worklist(&mut self) {
+        while !self.worklist.is_empty() {
+            let mut block = self.worklist.pop().unwrap();
+            let md = block.header().metadata();
+
+            if md.is_gc {
+                if block.colour() == Colour::Black {
+                    continue;
+                }
+                block.set_colour(Colour::Black);
+            }
+
+            // Check each word in the allocation block for pointers.
+            for addr in block.range().step_by(WORD_SIZE) {
+                let word = unsafe { *(addr as *const Word) };
+                if let Some(block) = self.collection_ctxt.find(word) {
+                    self.worklist.push(block)
+                }
+            }
+        }
+    }
 }
 
 /// A collector responsible for finding and freeing unreachable objects.
@@ -139,7 +223,7 @@ pub(crate) struct Collector {
     pub(crate) allocations: usize,
 }
 
-impl Collector {
+impl<'m, 's: 'm> Collector {
     pub(crate) const fn new() -> Self {
         Self {
             drop_queue: GcVec::new(),
@@ -161,14 +245,22 @@ impl Collector {
     /// triggered through this method. It is UB to call any of them
     /// individually.
     pub(crate) fn collect(&mut self) {
+        let allocation_cache = ALLOCATOR.sorted_cache();
+        let (data_segment_start, data_segment_end) = unsafe { get_data_segment_range() };
+        let mut colcx = CollectionCtxt {
+            allocation_cache,
+            data_segment_start,
+            data_segment_end,
+        };
+
         if self.debug_flags.prep_phase {
-            self.enter_preparation_phase();
+            self.enter_preparation_phase(&mut colcx);
         }
 
         COLLECTOR_PHASE.lock().update(CollectorPhase::Marking);
 
         if self.debug_flags.mark_phase {
-            self.enter_mark_phase();
+            self.enter_mark_phase(&mut colcx);
         }
 
         if self.debug_flags.sweep_phase {
@@ -185,9 +277,9 @@ impl Collector {
     /// The entry-point to the preperation phase.
     ///
     /// This sets the mark-bits of all garbage-collected objects to white.
-    fn enter_preparation_phase(&mut self) {
+    fn enter_preparation_phase(&mut self, col: &mut CollectionCtxt) {
         COLLECTOR_PHASE.lock().update(CollectorPhase::Preparation);
-        for mut block in ALLOCATOR.iter() {
+        for block in col.allocation_cache.iter_mut() {
             if block.header().metadata().is_gc {
                 block.set_colour(Colour::White)
             }
@@ -202,47 +294,18 @@ impl Collector {
     /// The mark phase colours blocks in the worklist which are managed by the
     /// collector. It also traverses the contents of **all** blocks for further
     /// pointers.
-    fn enter_mark_phase<'mrk>(&mut self) {
+    fn enter_mark_phase(&mut self, colcx: &'m mut CollectionCtxt<'s>) {
         COLLECTOR_PHASE.lock().update(CollectorPhase::Marking);
 
         let stack_start = unsafe { get_stack_start().unwrap() };
-        let (data_segment_start, data_segment_end) = unsafe { get_data_segment_range() };
 
         let mut ctxt = MarkingCtxt {
             worklist: GcVec::new(),
             stack_start,
-            data_segment_start,
-            data_segment_end,
+            collection_ctxt: colcx,
         };
 
-        // Register spilling is platform specific. This is implemented in
-        // an assembly stub. The fn to scan the stack is passed as a callback
-        unsafe { spill_registers(Collector::scan_stack, &mut ctxt) }
-
-        self.scan_statics(&mut ctxt);
-        self.mark_objects(&mut ctxt);
-    }
-
-    fn mark_objects<'mrk>(&mut self, ctxt: &mut MarkingCtxt<'mrk>) {
-        while !ctxt.worklist.is_empty() {
-            let mut block = ctxt.worklist.pop().unwrap();
-            let md = block.header().metadata();
-
-            if md.is_gc {
-                if block.colour() == Colour::Black {
-                    continue;
-                }
-                block.set_colour(Colour::Black);
-            }
-
-            // Check each word in the allocation block for pointers.
-            for addr in block.range().step_by(WORD_SIZE) {
-                let word = unsafe { *(addr as *const Word) };
-                if let Some(block) = Block::find(word, ctxt) {
-                    ctxt.worklist.push(block)
-                }
-            }
-        }
+        ctxt.mark();
     }
 
     /// The entry-point to the sweep phase.
@@ -275,35 +338,6 @@ impl Collector {
         while !self.drop_queue.is_empty() {
             let block = self.drop_queue.pop().unwrap();
             unsafe { block.drop() }
-        }
-    }
-
-    /// Scans the stack from bottom to top, starting from the position of the
-    /// current stack pointer. This method should never be called directly.
-    /// Instead, it should be invoked as a callback from a platform specific
-    /// assembly stub which is expected to get the contents of the stack pointer
-    /// and spill all registers which may contain roots.
-    #[no_mangle]
-    unsafe extern "sysv64" fn scan_stack<'mrk>(rsp: Address, ctxt: *mut MarkingCtxt<'mrk>) {
-        let ctxt = &mut *ctxt;
-
-        for stack_address in (rsp..ctxt.stack_start).step_by(WORD_SIZE) {
-            let stack_word = *(stack_address as *const Word);
-            if let Some(block) = Block::find(stack_word, ctxt) {
-                ctxt.worklist.push(block)
-            }
-        }
-    }
-
-    /// Roots can hide inside static variables, so these need scanning for
-    /// potential pointers too.
-    #[cfg(target_os = "linux")]
-    fn scan_statics<'mrk>(&mut self, ctxt: &mut MarkingCtxt<'mrk>) {
-        for data_addr in (ctxt.data_segment_start..ctxt.data_segment_end).step_by(WORD_SIZE) {
-            let static_word = unsafe { *(data_addr as *const Word) };
-            if let Some(block) = Block::find(static_word, ctxt) {
-                ctxt.worklist.push(block)
-            }
         }
     }
 }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -123,17 +123,8 @@ impl<T: ?Sized> GcBox<T> {
     pub(crate) fn set_colour(&mut self, colour: Colour) {
         self.block().set_colour(colour);
     }
-
-    pub(crate) fn set_dropped(&mut self, value: bool) {
-        self.block().set_dropped(value);
-    }
-
     pub(crate) fn set_drop_vptr(&mut self, value: *mut u8) {
         self.block().set_drop_vptr(value);
-    }
-
-    pub(crate) fn dropped(&self) -> bool {
-        self.block().dropped()
     }
 }
 
@@ -153,10 +144,10 @@ impl<T: ?Sized> DerefMut for Gc<T> {
 
 impl<T: ?Sized> Drop for GcBox<T> {
     fn drop(&mut self) {
-        if self.colour() == Colour::Black || self.dropped() {
+        println!("Dropping GcBox");
+        if self.colour() == Colour::Black {
             return;
         }
-        self.set_dropped(true);
         unsafe { ManuallyDrop::drop(&mut self.0) };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,9 @@ pub use collector::DebugFlags;
 pub use gc::Gc;
 
 use crate::{
-    allocator::{GcAllocator, GlobalAllocator},
-    collector::{Collector, CollectorPhase, OpaqueU8},
-    gc::{Colour, GcBox},
+    allocator::{Block, GcAllocator, GlobalAllocator},
+    collector::{Collector, CollectorPhase},
+    gc::Colour,
 };
 
 use parking_lot::Mutex;
@@ -79,12 +79,12 @@ impl Debug {
     pub fn is_black<T>(gc: *mut T) -> bool {
         assert_eq!(*COLLECTOR_PHASE.lock(), CollectorPhase::Ready);
 
-        let obj = unsafe { &*(gc as *const GcBox<OpaqueU8>) };
-        obj.colour() == Colour::Black
+        let block = Block::new(gc as *mut u8);
+        block.colour() == Colour::Black
     }
 
     pub unsafe fn keep_alive<T>(gc: Gc<T>) {
-        let obj = &mut *(gc.objptr.as_ptr() as *mut GcBox<OpaqueU8>);
-        obj.set_colour(Colour::Black)
+        let mut block = Block::new(gc.objptr.as_ptr() as *mut u8);
+        block.set_colour(Colour::Black);
     }
 }


### PR DESCRIPTION
During marking, pointer identification is slow because it needs to
traverse a linked-list spanning the entire heap while looking for a
pointer. We now sort and cache block pointers in-use by the mutator when
a collection is triggered so that they can be looked up in O(logn) using
binary search.

Unfortunately this required quite a bit of code shuffling to keep the
borrow checker happy from the previous couple of PRs.