### PR TITLE
Allow construction of uninitialized Gc values

### DIFF
--- a/gc_tests/tests/new_from_layout.rs
+++ b/gc_tests/tests/new_from_layout.rs
@@ -1,0 +1,55 @@
+// Run-time:
+//   status: success
+
+extern crate gcmalloc;
+
+use gcmalloc::{collect, Debug, DebugFlags, Gc};
+use std::alloc::Layout;
+
+static mut COUNTER: usize = 0;
+
+struct Inner;
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        unsafe { COUNTER += 1 }
+    }
+}
+
+struct Large([usize; 10]);
+
+fn main() {
+    // Ensure that collection will always reclaim the object.
+    gcmalloc::debug_flags(DebugFlags::new().mark_phase(false));
+
+    let layout = Layout::from_size_align(8, 8).unwrap();
+
+    // First, check that we can't create a Gc value for a layout smaller than T.
+    let l = Gc::<Large>::new_from_layout(layout);
+    assert!(l.is_none());
+
+    // Since we obtain a Gc<MaybeUninit<T>>, no drop should be called on T if it
+    // was never initialized.
+    let x = Gc::<Inner>::new_from_layout(layout).unwrap();
+    gcmalloc::collect();
+    unsafe { assert_eq!(COUNTER, 0) }
+
+    // Calling `assume_init()` will promote a Gc<MaybeUninit<T> to a Gc<T>,
+    // meaning that T's drop method should now be called upon collection.
+    let x = Gc::<Inner>::new_from_layout(layout).unwrap();
+    unsafe { x.assume_init() };
+    gcmalloc::collect();
+    unsafe { assert_eq!(COUNTER, 1) }
+
+    unsafe {
+        let x = Gc::<Inner>::new_from_layout(layout).unwrap();
+        let y = x.clone().assume_init();
+        let z = x.clone().assume_init();
+        x.assume_init();
+
+        // We can do this multiple times, but the end result should still be
+        // that the underlying Gc value is only dropped once upon collection.
+        gcmalloc::collect();
+        assert_eq!(COUNTER, 2);
+    }
+}

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -299,6 +299,10 @@ impl<'a> Block<'a> {
         let layout = Layout::from_size_align_unchecked(size, align);
 
         ::std::ptr::drop_in_place(fatptr);
+        self.dealloc(layout)
+    }
+
+    pub(crate) unsafe fn dealloc(self, layout: Layout) {
         crate::GC_ALLOCATOR.dealloc(NonNull::new_unchecked(self.base), layout);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(const_fn)]
 #![feature(coerce_unsized)]
 #![feature(unsize)]
+#![feature(maybe_uninit_ref)]
 #[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
 compile_error!("Requires x86_64 with 64 bit pointer width.");
 
@@ -84,7 +85,7 @@ impl Debug {
     }
 
     pub unsafe fn keep_alive<T>(gc: Gc<T>) {
-        let mut block = Block::new(gc.objptr.as_ptr() as *mut u8);
+        let mut block = Block::new(gc.ptr.as_ptr() as *mut u8);
         block.set_colour(Colour::Black);
     }
 }


### PR DESCRIPTION
This lets us create a Gc value to a `Gc<MaybeUninit<T>>` with a new constructor:

```rust
pub fn new_from_layout<T>(layout: Layout) -> Option<Gc<T>> 
```

The constructor returns `None` if `layout` is less than `size_of::<T>()` because
this could accidentally trigger out-of-bounds accesses.

Since a `Gc<MaybeUninit<T>>` will not be dropped until it is initialized, we
also need to modify the sweep and finalization phases to make sure of this.