### PR TITLE
Mark non-garbage-collected blocks during the mark phase

### DIFF
--- a/gc_tests/tests/cycle_in_non_gc_value_object_graph.rs
+++ b/gc_tests/tests/cycle_in_non_gc_value_object_graph.rs
@@ -1,0 +1,34 @@
+// Run-time:
+//  status: success
+
+extern crate gcmalloc;
+
+use gcmalloc::{collect, Debug, DebugFlags, Gc};
+
+struct S {
+    x: usize,
+    y: Gc<usize>,
+}
+
+fn main() {
+    gcmalloc::debug_flags(DebugFlags::new().sweep_phase(false));
+
+    let mut s = Box::new(S {
+        x: 0,
+        y: Gc::new(123),
+    });
+
+    // We take a reference to a non-garbage-collected heap object and place it
+    // inside its own heap contents with the knowledge that the collector will
+    // look through its fields and enqueue them for marking.
+    //
+    // If the original object hasn't been marked as "seen" before any of its
+    // fields are popped off the queue and processed then we can end up in an
+    // infinite loop.
+    s.x = s.as_ref() as *const _ as usize;
+
+    gcmalloc::collect();
+
+    // If we get here, then the test has passed as it didn't get stuck in a
+    // cycle.
+}

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -164,14 +164,11 @@ impl<'mrk, 'col> MarkingCtxt<'mrk, 'col> {
     fn process_worklist(&mut self) {
         while !self.worklist.is_empty() {
             let mut block = self.worklist.pop().unwrap();
-            let md = block.header().metadata();
-
-            if md.is_gc {
-                if block.colour() == Colour::Black {
-                    continue;
-                }
-                block.set_colour(Colour::Black);
+            if block.colour() == Colour::Black {
+                continue;
             }
+
+            block.set_colour(Colour::Black);
 
             // Check each word in the allocation block for pointers.
             for addr in block.range().step_by(WORD_SIZE) {


### PR DESCRIPTION
Non-garbage-collected values can reference each other cyclically, and
unless there is a notion of one having already been "seen" during the
mark phase then this has the potential to end up in an infinite loop.