### PR TITLE
Fix use-after-free in preparation phase of collection

### DIFF
--- a/gc_tests/tests/prep_phase_resets_non_gc_objects.rs
+++ b/gc_tests/tests/prep_phase_resets_non_gc_objects.rs
@@ -1,0 +1,24 @@
+// Run-time:
+//  status: success
+
+extern crate gcmalloc;
+
+use gcmalloc::{collect, Debug, DebugFlags, Gc};
+
+fn main() {
+    gcmalloc::debug_flags(DebugFlags::new().sweep_phase(false));
+
+    let x = Box::new(Gc::new(123));
+
+    // The first collection should colour x black.
+    gcmalloc::collect();
+
+    assert!(Debug::is_black(x.as_ref() as *const _ as *mut u8));
+
+    // The preparation phase for the second collection should reset x to white.
+    // If it doesn't, then values could be missed.
+    gcmalloc::debug_flags(DebugFlags::new().sweep_phase(false).mark_phase(false));
+    gcmalloc::collect();
+
+    assert!(!Debug::is_black(x.as_ref() as *const _ as *mut u8));
+}

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -279,9 +279,7 @@ impl<'m, 's: 'm> Collector {
     fn enter_preparation_phase(&mut self, col: &mut CollectionCtxt) {
         COLLECTOR_PHASE.lock().update(CollectorPhase::Preparation);
         for block in col.allocation_cache.iter_mut() {
-            if block.header().metadata().is_gc {
-                block.set_colour(Colour::White)
-            }
+            block.set_colour(Colour::White)
         }
     }
 


### PR DESCRIPTION
After switching the collector to colour both GC and non-GC values during
marking, I forgot to update the preparation phase. This led to the
collector assuming some values' fields had already been traced. If those
fields were the only thing pointing to live values in the graph, then
those live values were erroneously freed.