### PR TITLE
Add mechanism for specifying how the GC should trace values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ packed_struct = "0.3"
 packed_struct_codegen = "0.3"
 parking_lot = { version = "0.10", features = ["nightly"] }
 static_assertions = "1.1"
+trace_derive = { path = "trace_derive" }
 
 [build-dependencies]
 rerun_except = "0.1"
@@ -23,3 +24,5 @@ tempdir = "0.3"
 name = "gc_tests"
 path = "gc_tests/run_tests.rs"
 harness = false
+
+[workspace]

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,7 +1,7 @@
 use stdalloc::raw_vec::RawVec;
 
 use std::{
-    alloc::{Alloc, AllocErr, GlobalAlloc, Layout, System},
+    alloc::{AllocErr, AllocRef, GlobalAlloc, Layout, System},
     marker::PhantomData,
     ptr,
     ptr::NonNull,
@@ -43,7 +43,7 @@ unsafe impl GlobalAlloc for GlobalAllocator {
     }
 }
 
-unsafe impl Alloc for GcAllocator {
+unsafe impl AllocRef for GcAllocator {
     unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
         let mut c = COLLECTOR.lock();
         c.poll();

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -1,5 +1,5 @@
 use std::{
-    alloc::{Alloc, Layout},
+    alloc::{AllocRef, Layout},
     any::Any,
     fmt,
     marker::{PhantomData, Unsize},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ extern crate static_assertions;
 pub mod allocator;
 pub mod collector;
 pub mod gc;
+pub mod trace;
 
 pub use collector::DebugFlags;
 pub use gc::Gc;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,0 +1,67 @@
+#[derive(Debug, PartialEq)]
+pub enum TraceType {
+    Conservative,
+    Custom,
+}
+
+/// The trait used by the collector to determine how an object's fields should
+/// be traced.
+pub trait Trace {
+    fn trace(&self, _: &mut Vec<usize>) -> TraceType {
+        TraceType::Conservative
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trace_derive::Trace;
+
+    #[test]
+    fn custom_trace() {
+        fn unmask_fn(x: usize) -> *const u8 {
+            (x + 1) as *const u8
+        }
+
+        #[derive(Trace)]
+        struct S {
+            #[trace = "unmask_fn"]
+            x: usize,
+        }
+
+        let s = S { x: 0 };
+        let mut trace_stack = Vec::<usize>::new();
+        let tt = s.trace(&mut trace_stack);
+        assert_eq!(tt, TraceType::Custom);
+        assert_eq!(trace_stack[0], 1);
+    }
+
+    #[test]
+    fn custom_trace_records_all_fields() {
+        fn unmask_fn(x: usize) -> *const u8 {
+            (x + 1) as *const u8
+        }
+
+        struct T;
+        #[derive(Trace)]
+        struct S<'a> {
+            #[trace = "unmask_fn"]
+            x: usize,
+            _y: *mut u8,
+            #[trace]
+            z: &'a T,
+        }
+
+        let t = T {};
+        let s = S {
+            x: 0,
+            _y: 123 as *mut u8,
+            z: &t,
+        };
+        let mut trace_stack = Vec::<usize>::new();
+        let tt = s.trace(&mut trace_stack);
+
+        assert_eq!(tt, TraceType::Custom);
+        assert_eq!(trace_stack, &[s.z as *const _ as usize, 1]);
+    }
+}

--- a/trace_derive/Cargo.toml
+++ b/trace_derive/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "trace_derive"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "0.15"
+quote = "0.6"

--- a/trace_derive/src/lib.rs
+++ b/trace_derive/src/lib.rs
@@ -1,0 +1,72 @@
+extern crate proc_macro;
+
+use crate::proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Error, Field, Lit, Meta, MetaNameValue, Path};
+
+#[proc_macro_derive(Trace, attributes(trace))]
+pub fn traceable_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    let generics = input.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let fields = match &input.data {
+        Data::Struct(s) => &s.fields,
+        _ => panic!("Expected a struct"),
+    };
+
+    let fields: Result<Vec<_>, Error> = fields.iter().map(|field| get_trace(field)).collect();
+
+    let (masked, unmasked): (Vec<_>, Vec<_>) = fields
+        .unwrap()
+        .into_iter()
+        .filter_map(|x| x)
+        .partition(|x| x.1.is_some());
+
+    // I've not worked out how to split a tuple during quote! interpolation.
+    // Until I'm aware of a cleaner way, we're stuck with the boilerplate below.
+    let unmasked_name = unmasked.iter().map(|x| &x.0.ident);
+    let masked_name = masked.iter().map(|x| &x.0.ident);
+    let masked_fn = masked.iter().map(|x| &x.1);
+
+    fn get_trace(field: &Field) -> Result<Option<(&Field, Option<Path>)>, Error> {
+        for attr in field.attrs.iter() {
+            if !attr.path.is_ident("trace") {
+                continue;
+            }
+
+            match attr.parse_meta()? {
+                Meta::Word(_) => return Ok(Some((&field, None))),
+                Meta::NameValue(MetaNameValue {
+                    lit: Lit::Str(lit_str),
+                    ..
+                }) => return lit_str.parse().map(|x| Some((field, Some(x)))),
+                _ => {
+                    let message = "expected #[trace = \"...\"]";
+                    return Err(Error::new_spanned(attr, message));
+                }
+            }
+        }
+        return Ok(None);
+    }
+
+    let expanded = quote! {
+        impl #impl_generics Trace for #name #ty_generics #where_clause {
+            fn trace(&self, current: &mut Vec<usize>) -> TraceType {
+                    #(
+                        current.push(self.#unmasked_name as *const _ as usize);
+                     )*
+
+                    #(
+                        let ptr: *const u8 = #masked_fn(self.#masked_name);
+                        current.push(ptr as usize);
+                     )*
+
+                    TraceType::Custom
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}


### PR DESCRIPTION
The collector currently treats all objects it encounters as opaque
blocks of possible pointer values. It then scans through these,
word-by-word, checking whether these possible pointers extend the object
graph. This approach is very simple, but it can miss pointers if they
are stored 'opaquely'. In other words, pointers which are stored in a
way which require some form of de-obfuscation before they can be
dereferenced will be missed by the collector.

To mitigate this, we need a way for the user to be able to tell the gc
that certain fields require de-obfuscating before they can be treated as
pointers. In this commit, we flesh out such an API.

The basic idea is to introduce a `Trace` trait for types to implement if they
contain opaque pointers. It defines as single `trace` method which
specifies how pointer fields can be de-obfuscated by the collector.

The `Trace` trait should not be implemented directly by the user,
however. Instead, we provide a custom derive attribute which we expect
users to use. Consider the following struct:
```rust
    struct S {
        opaque_ptr: usize,
        no_ptr: usize,
        normal_ptr: *mut Vec<...>
    }
```
If the collector traced `S` conservatively, it would miss this pointer
stored in the `opaque_ptr` field. To tell the collector how to
de-obfuscate it, we derive `Trace` and use a field level attribute as
shown below:
```rust
    #[derive(Trace)]
    struct S {
        #[trace = "path::to::deobfuscation::fn"]
        opaque_ptr: usize,
        no_ptr: usize,
        #[trace]
        normal_ptr: *mut Vec<...>
    }
```
The user needs to write a function to de-obfuscate each opaque field,
and then link it to the required field in the with the attribute:
`#[trace = "..."]`. The de-obfuscation function should take a single
argument, whose type is that of the field and return a pointer with the
type `*const u8`. For example, a de-obfuscation function for
`opaque_field` above might look like this:
```rust
    fn deobf_opaque_ptr(field: usize) -> *const u8 {
        (field | SOME_MASK) as *const u8
    }
```
Since a type which implements `Trace` will no longer be conservatively
traced, the user must also annotate other pointer-like fields which lead
to Gc values. This is done as above with the `#[trace]` attribute. This
is clearly error-prone and undesirable, and in the future this will not
be necessary.

This is insufficient to describe all types which may need a custom
tracing mechanism. However, I think it is quite ergonomic for the
common-case, and it can be built upon for more complex trace semantics.

The GC code required to respect this `Trace` API has not yet been
implemented.