### PR TITLE
Replace tempdir with tempfile

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -10,8 +10,16 @@ sh rustup.sh --default-host x86_64-unknown-linux-gnu --default-toolchain nightly
 
 export PATH=`pwd`/.cargo/bin/:$PATH
 
-rustup component add --toolchain nightly rustfmt-preview || cargo +nightly install --force rustfmt-nightly
-
-cargo +nightly fmt --all -- --check gc_tests/tests/*
+# Sometimes rustfmt is so broken that there is no way to install it at all.
+# Rather than refusing to merge, we just can't rust rustfmt at such a point.
+rustup component add --toolchain nightly rustfmt-preview \
+    || cargo +nightly install --force rustfmt-nightly \
+    || true
+rustfmt=0
+cargo fmt 2>&1 | grep "not installed for the toolchain" > /dev/null || rustfmt=1
+if [ $rustfmt -eq 1 ]; then
+    cargo +nightly fmt --all -- --check gc_tests/tests/*
+    cargo +nightly fmt --all -- --check
+fi
 
 cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cc = "1.0"
 
 [dev-dependencies]
 lang_tester = "0.3"
-tempdir = "0.3"
+tempfile = "3.1.0"
 
 [[test]]
 name = "gc_tests"

--- a/gc_tests/run_tests.rs
+++ b/gc_tests/run_tests.rs
@@ -1,7 +1,7 @@
 use std::{env, path::PathBuf, process::Command};
 
 use lang_tester::LangTester;
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 static CRATE_NAME: &'static str = "gcmalloc";
 
@@ -41,7 +41,7 @@ fn main() {
         .output()
         .expect("Failed to build libs");
 
-    let tempdir = TempDir::new("gc_tester").unwrap();
+    let tempdir = TempDir::new().unwrap();
     LangTester::new()
         .test_dir("gc_tests/tests")
         .test_file_filter(|p| {
@@ -86,7 +86,7 @@ fn main() {
         })
         .run();
 
-    let tempdir = TempDir::new("gc_tester").unwrap();
+    let tempdir = TempDir::new().unwrap();
     LangTester::new()
         .test_dir("gc_tests/tests")
         .test_file_filter(|p| p.extension().unwrap().to_str().unwrap() == "rs")


### PR DESCRIPTION
tempdir is deprecated and presents as a security vulnerability in cargo
audit.